### PR TITLE
Fix comment typo in env file

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -15,7 +15,7 @@ BYOC_NEUROSYNC_CAPABILITY_CAPACITY=1
 # Orchestrator Configuration (Note: Some overlap with Neurosync Capability, review if needed)
 BYOC_ORCHESTRATOR_PRICE_PER_UNIT=1
 
-# Eliza variables bellow
+# Eliza variables below
 
 # Logging Configuration (supported: fatal, error, warn, info, debug, trace | default: info)
 LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- fix a typo in `.example.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*