### PR TITLE
Add analytics skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ Enjoy your VTubing experience!
 
 We are actively working on streamlining this setup process. Future updates will aim to provide a more straightforward installation experience, potentially through unified scripts or enhanced Docker configurations.
 
+## 📊 Analytics Integration
+
+The repository now ships with a flexible analytics module in `analytics/`.
+It defines an abstract interface and two concrete providers:
+
+* **`InMemoryAnalytics`** – a simple backend used by the tests.
+* **`MetabaseAnalytics`** – communicates with a Metabase server over HTTP.
+
+Autonomous agents can leverage this API to create analytics boards, import data, and query dashboards programmatically. To use the Metabase provider:
+
+```python
+from analytics import MetabaseAnalytics
+
+analytics = MetabaseAnalytics("http://metabase.local", "user", "pass")
+board_id = analytics.create_board("Demo")
+analytics.import_data(board_id, [{"value": 1}, {"value": 2}])
+```
+
+Boards can then be inspected in Metabase's dashboard UI.
+
+
 ## 🤝 Contributing
 
 Contributions are welcome! If you encounter any issues, have suggestions for improvements, or would like to contribute to the development, please feel free to open an issue or submit a pull request on the respective GitHub repositories.

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,7 @@
+"""Analytics module providing a minimal abstract interface."""
+
+from .base import AnalyticsBase
+from .in_memory import InMemoryAnalytics
+from .metabase import MetabaseAnalytics
+
+__all__ = ["AnalyticsBase", "InMemoryAnalytics", "MetabaseAnalytics"]

--- a/analytics/base.py
+++ b/analytics/base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable
+
+
+class AnalyticsBase(ABC):
+    """Abstract interface for analytics providers."""
+
+    @abstractmethod
+    def create_board(self, name: str) -> str:
+        """Create a new analytics board and return its identifier."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def import_data(self, board_id: str, data: Iterable[Dict[str, Any]]) -> None:
+        """Import a collection of records into the given board."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_board(self, board_id: str) -> Dict[str, Any]:
+        """Return metadata for the specified board."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_boards(self) -> Iterable[Dict[str, Any]]:
+        """Return iterable of available boards."""
+        raise NotImplementedError

--- a/analytics/in_memory.py
+++ b/analytics/in_memory.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+import itertools
+
+from .base import AnalyticsBase
+
+
+class InMemoryAnalytics(AnalyticsBase):
+    """Simple in-memory analytics provider used for testing."""
+
+    def __init__(self) -> None:
+        self._boards: Dict[str, Dict[str, Any]] = {}
+        self._data: Dict[str, List[Dict[str, Any]]] = {}
+        self._id_counter = itertools.count(1)
+
+    def create_board(self, name: str) -> str:
+        board_id = f"board-{next(self._id_counter)}"
+        self._boards[board_id] = {"id": board_id, "name": name}
+        self._data[board_id] = []
+        return board_id
+
+    def import_data(self, board_id: str, data: Iterable[Dict[str, Any]]) -> None:
+        if board_id not in self._boards:
+            raise KeyError(f"Unknown board_id {board_id}")
+        self._data[board_id].extend(list(data))
+
+    def get_board(self, board_id: str) -> Dict[str, Any]:
+        return self._boards[board_id]
+
+    def list_boards(self) -> Iterable[Dict[str, Any]]:
+        return list(self._boards.values())
+
+    def get_board_data(self, board_id: str) -> List[Dict[str, Any]]:
+        return list(self._data.get(board_id, []))

--- a/analytics/metabase.py
+++ b/analytics/metabase.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Any, Dict, Iterable, List
+
+from .base import AnalyticsBase
+
+
+class MetabaseAnalytics(AnalyticsBase):
+    """Analytics provider that communicates with a Metabase server via its REST API."""
+
+    def __init__(self, base_url: str, username: str, password: str) -> None:
+        self.base_url = base_url.rstrip('/')
+        self.username = username
+        self.password = password
+        self._session_id: str | None = None
+        self._login()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _request(self, method: str, path: str, payload: Dict[str, Any] | None = None) -> Any:
+        url = f"{self.base_url}{path}"
+        data: bytes | None = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode('utf-8')
+            headers['Content-Type'] = 'application/json'
+        if self._session_id:
+            headers['X-Metabase-Session'] = self._session_id
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read()
+            if body:
+                return json.loads(body)
+            return None
+
+    def _login(self) -> None:
+        resp = self._request(
+            'POST',
+            '/api/session',
+            {'username': self.username, 'password': self.password},
+        )
+        self._session_id = resp['id']
+
+    # ------------------------------------------------------------------
+    # Public API
+    def create_board(self, name: str) -> str:
+        resp = self._request('POST', '/api/collection', {'name': name})
+        return str(resp['id'])
+
+    def import_data(self, board_id: str, data: Iterable[Dict[str, Any]]) -> None:
+        self._request('POST', '/api/dataset', {'board_id': board_id, 'rows': list(data)})
+
+    def get_board(self, board_id: str) -> Dict[str, Any]:
+        return self._request('GET', f'/api/collection/{board_id}')
+
+    def list_boards(self) -> Iterable[Dict[str, Any]]:
+        return self._request('GET', '/api/collection')
+
+    # Convenience accessor similar to InMemoryAnalytics
+    def get_board_data(self, board_id: str) -> List[Dict[str, Any]]:
+        board = self.get_board(board_id)
+        return board.get('rows', [])

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,25 @@
+import unittest
+
+from analytics.in_memory import InMemoryAnalytics
+
+
+class InMemoryAnalyticsTests(unittest.TestCase):
+    def test_create_import_and_list(self):
+        analytics = InMemoryAnalytics()
+        board_id = analytics.create_board("demo")
+        analytics.import_data(board_id, [{"x": 1}, {"x": 2}])
+
+        board = analytics.get_board(board_id)
+        self.assertEqual(board["name"], "demo")
+
+        boards = list(analytics.list_boards())
+        self.assertEqual(len(boards), 1)
+        self.assertEqual(boards[0]["id"], board_id)
+
+        data = analytics.get_board_data(board_id)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["x"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_metabase_analytics.py
+++ b/tests/test_metabase_analytics.py
@@ -1,0 +1,108 @@
+import http.server
+import json
+import threading
+import itertools
+import unittest
+
+from analytics.metabase import MetabaseAnalytics
+
+
+class FakeMetabaseServer:
+    def __init__(self):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            boards: dict[str, dict] = {}
+            board_data: dict[str, list] = {}
+            counter = itertools.count(1)
+
+            def _json_response(self, code: int, obj: dict | list):
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(obj).encode())
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                data = json.loads(self.rfile.read(length) or b"{}")
+                if self.path == "/api/session":
+                    if data.get("username") == "user" and data.get("password") == "pass":
+                        self._json_response(200, {"id": "token"})
+                    else:
+                        self._json_response(403, {"error": "forbidden"})
+                elif self.path == "/api/collection":
+                    if self.headers.get("X-Metabase-Session") != "token":
+                        self._json_response(401, {"error": "unauthorized"})
+                        return
+                    board_id = str(next(self.counter))
+                    self.boards[board_id] = {"id": board_id, "name": data.get("name")}
+                    self.board_data[board_id] = []
+                    self._json_response(200, self.boards[board_id])
+                elif self.path == "/api/dataset":
+                    if self.headers.get("X-Metabase-Session") != "token":
+                        self._json_response(401, {"error": "unauthorized"})
+                        return
+                    board_id = data.get("board_id")
+                    rows = data.get("rows", [])
+                    self.board_data.setdefault(board_id, []).extend(rows)
+                    self._json_response(200, {})
+                else:
+                    self._json_response(404, {"error": "not found"})
+
+            def do_GET(self):
+                if self.headers.get("X-Metabase-Session") != "token":
+                    self._json_response(401, {"error": "unauthorized"})
+                    return
+                if self.path == "/api/collection":
+                    self._json_response(200, list(self.boards.values()))
+                elif self.path.startswith("/api/collection/"):
+                    board_id = self.path.split("/")[-1]
+                    board = self.boards.get(board_id)
+                    if board:
+                        board_with_data = dict(board)
+                        board_with_data["rows"] = self.board_data[board_id]
+                        self._json_response(200, board_with_data)
+                    else:
+                        self._json_response(404, {"error": "not found"})
+                else:
+                    self._json_response(404, {"error": "not found"})
+
+            def log_message(self, *args, **kwargs):
+                pass
+
+        self._server = http.server.ThreadingHTTPServer(("localhost", 0), Handler)
+        host, port = self._server.server_address
+        self.url = f"http://{host}:{port}"
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.daemon = True
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join()
+
+
+class MetabaseAnalyticsTests(unittest.TestCase):
+    def setUp(self):
+        self.server = FakeMetabaseServer()
+        self.server.start()
+        self.analytics = MetabaseAnalytics(self.server.url, "user", "pass")
+
+    def tearDown(self):
+        self.server.stop()
+
+    def test_full_flow(self):
+        board_id = self.analytics.create_board("demo")
+        self.analytics.import_data(board_id, [{"x": 1}, {"x": 2}])
+        board = self.analytics.get_board(board_id)
+        self.assertEqual(board["name"], "demo")
+        self.assertEqual(len(board["rows"]), 2)
+
+        boards = list(self.analytics.list_boards())
+        self.assertEqual(len(boards), 1)
+        self.assertEqual(boards[0]["id"], board_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new analytics module with abstract base class and in-memory implementation
- document the analytics integration in README
- add unit tests for analytics
- integrate with Metabase and add tests for the HTTP provider

## Testing
- `python -m unittest discover -s tests`
