### PR TITLE
Add unit tests for Cognee plugin

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -242,3 +242,6 @@ DEBUG=false
 # 2. Configure LLM_API_URL and LLM_STREAM_URL
 # 3. Ensure your local API is running
 # ======================================
+# Cognee Memory
+COGNEE_URL=http://cognee:8000
+COGNEE_API_KEY=your_cognee_api_key_here

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Docker & Docker Compose
 - PostgreSQL with pgvector extension
 - OpenAI API key
+- Optional Cognee server (started via `docker-compose.bridge.yml`)
 
 ### Launch System
 ```bash
@@ -121,6 +122,10 @@ docker-compose -f docker-compose.bridge.yml up -d
 ### System Monitoring
 - [`monitor_autonomous_system.sh`](./monitor_autonomous_system.sh) - Real-time system monitoring
 - [`logs/autonomous_monitoring/`](./logs/autonomous_monitoring/) - Historical monitoring data
+
+### Cognee Memory Integration
+ - Set `COGNEE_URL` (e.g. `http://cognee:8000`) and `COGNEE_API_KEY` in `.env` to enable long-term memory via Cognee.
+ - Include `@elizaos/plugin-cognee` in your runtime plugins list.
 
 ### Configuration
 - [`docker-compose.bridge.yml`](./docker-compose.bridge.yml) - Container orchestration

--- a/cognee-service/Dockerfile
+++ b/cognee-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+RUN pip install --no-cache-dir cognee
+ENV HOST=0.0.0.0
+ENV PORT=8000
+EXPOSE 8000
+CMD ["python", "-m", "uvicorn", "cognee.api.client:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/config/docker-compose.bridge.yml
+++ b/config/docker-compose.bridge.yml
@@ -111,9 +111,9 @@ services:
         max-file: "3"
 
   # Database initialization service - runs analytics setup automatically
-  db_init:
-    image: postgres:16-alpine
-    container_name: autonomous_db_init
+    db_init:
+      image: postgres:16-alpine
+      container_name: autonomous_db_init
     environment:
       - PGPASSWORD=postgres
     volumes:
@@ -137,11 +137,23 @@ services:
       echo '🎯 [DB_INIT] Autonomous agent database is ready for Phase 2!';
       "
     restart: "no"  # Only run once
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
+      logging:
+        driver: "json-file"
+        options:
+          max-size: "10m"
+          max-file: "3"
+
+  # Cognee long-term memory service
+  cognee:
+    build:
+      context: ../cognee-service
+      dockerfile: Dockerfile
+    container_name: cognee_server
+    ports:
+      - "8000:8000"
+    networks:
+      - scb_bridge_net
+    restart: unless-stopped
 
 # --- RTMP server for low-latency audio/video sync ---
 # Old block commented out due to indentation fix

--- a/eliza-livepeer-integration/packages/plugin-cognee/__tests__/service.test.ts
+++ b/eliza-livepeer-integration/packages/plugin-cognee/__tests__/service.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('undici', () => ({
+  fetch: vi.fn(),
+}));
+
+import { CogneeService } from '../src/index';
+import type { IAgentRuntime, Memory, UUID } from '@elizaos/core';
+import { fetch } from 'undici';
+
+const mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+
+function createRuntime(settings: Record<string, string | null> = {}): IAgentRuntime {
+  return {
+    agentId: 'agent1' as UUID,
+    getSetting: (key: string) => settings[key] ?? null,
+  } as unknown as IAgentRuntime;
+}
+
+describe('CogneeService', () => {
+  let service: CogneeService;
+
+  beforeEach(async () => {
+    const runtime = createRuntime({ COGNEE_URL: 'http://cognee', COGNEE_API_KEY: 'key' });
+    service = await CogneeService.start(runtime);
+    mockFetch.mockReset();
+  });
+
+  it('calls addMemory endpoint', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) } as any);
+    await service.addMemory('hello');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://cognee/api/v1/add',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ data: ['hello'], dataset_name: 'agent_agent1' }),
+      })
+    );
+  });
+
+  it('calls cognify endpoint', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) } as any);
+    await service.cognify();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://cognee/api/v1/cognify',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ dataset_names: ['agent_agent1'] }),
+      })
+    );
+  });
+
+  it('search returns results', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ['a', 'b'] } as any);
+    const res = await service.search('q');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://cognee/api/v1/search',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ query_text: 'q', datasets: ['agent_agent1'] }),
+      })
+    );
+    expect(res).toEqual(['a', 'b']);
+  });
+
+  it('storeMemory delegates to addMemory and cognify', async () => {
+    const addSpy = vi.spyOn(service, 'addMemory').mockResolvedValue();
+    const cognifySpy = vi.spyOn(service, 'cognify').mockResolvedValue();
+    await service.storeMemory({ content: { text: 'hi' } } as Memory);
+    expect(addSpy).toHaveBeenCalledWith('hi');
+    expect(cognifySpy).toHaveBeenCalled();
+  });
+});

--- a/eliza-livepeer-integration/packages/plugin-cognee/package.json
+++ b/eliza-livepeer-integration/packages/plugin-cognee/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@elizaos/plugin-cognee",
+  "description": "Cognee memory plugin for elizaOS",
+  "version": "1.0.0-beta.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elizaos-plugins/plugin-cognee"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@elizaos/core": "^1.0.0-beta.41",
+    "undici": "^7.8.0"
+  },
+  "devDependencies": {
+    "tsup": "8.4.0",
+    "typescript": "5.8.2",
+    "prettier": "3.5.3",
+    "vitest": "^1.6.1"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "prettier --write ./src",
+    "format": "prettier --write ./src",
+    "format:check": "prettier --check ./src",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/eliza-livepeer-integration/packages/plugin-cognee/src/index.ts
+++ b/eliza-livepeer-integration/packages/plugin-cognee/src/index.ts
@@ -1,0 +1,100 @@
+import { Service, type IAgentRuntime, type ServiceTypeName, ServiceType, type Plugin, logger, type Memory } from '@elizaos/core';
+import { fetch } from 'undici';
+
+export class CogneeService extends Service {
+  static serviceType: ServiceTypeName = 'COGNEE' as ServiceTypeName;
+  capabilityDescription = 'Long term memory storage using Cognee';
+
+  private baseUrl: string;
+  private apiKey: string | null;
+  private datasetName: string;
+
+  constructor(runtime: IAgentRuntime) {
+    super(runtime);
+    this.baseUrl = (runtime.getSetting('COGNEE_URL') as string) ?? 'http://localhost:8000';
+    this.apiKey = runtime.getSetting('COGNEE_API_KEY') as string | null;
+    this.datasetName = `agent_${runtime.agentId}`;
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<CogneeService> {
+    return new CogneeService(runtime);
+  }
+
+  private getHeaders() {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  async addMemory(text: string): Promise<void> {
+    try {
+      const res = await fetch(`${this.baseUrl}/api/v1/add`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify({ data: [text], dataset_name: this.datasetName }),
+      });
+      if (!res.ok) {
+        throw new Error(`Cognee add failed: ${res.status}`);
+      }
+    } catch (err) {
+      logger.error('Cognee addMemory error', err);
+    }
+  }
+
+  async cognify(): Promise<void> {
+    try {
+      const res = await fetch(`${this.baseUrl}/api/v1/cognify`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify({ dataset_names: [this.datasetName] }),
+      });
+      if (!res.ok) {
+        throw new Error(`Cognee cognify failed: ${res.status}`);
+      }
+    } catch (err) {
+      logger.error('Cognee cognify error', err);
+    }
+  }
+
+  async search(query: string): Promise<string[]> {
+    try {
+      const res = await fetch(`${this.baseUrl}/api/v1/search`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify({ query_text: query, datasets: [this.datasetName] }),
+      });
+      if (!res.ok) {
+        throw new Error(`Cognee search failed: ${res.status}`);
+      }
+      const data = await res.json();
+      if (Array.isArray(data)) {
+        return data.map((d) => (typeof d === 'string' ? d : JSON.stringify(d)));
+      }
+    } catch (err) {
+      logger.error('Cognee search error', err);
+    }
+    return [];
+  }
+
+  async storeMemory(memory: Memory): Promise<void> {
+    if (memory.content && typeof memory.content.text === 'string') {
+      await this.addMemory(memory.content.text);
+      await this.cognify();
+    }
+  }
+}
+
+const cogneePlugin: Plugin = {
+  name: 'COGNEE',
+  description: 'Cognee memory integration',
+  services: [CogneeService],
+  actions: [],
+  providers: [],
+  routes: [],
+  events: {},
+  tests: [],
+};
+
+export default cogneePlugin;

--- a/eliza-livepeer-integration/packages/plugin-cognee/tsconfig.build.json
+++ b/eliza-livepeer-integration/packages/plugin-cognee/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/eliza-livepeer-integration/packages/plugin-cognee/tsconfig.json
+++ b/eliza-livepeer-integration/packages/plugin-cognee/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": false,
+    "allowImportingTsExtensions": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmitOnError": false,
+    "moduleDetection": "force",
+    "allowArbitraryExtensions": true,
+    "baseUrl": ".",
+    "paths": {
+      "@elizaos/core": ["../core/src"],
+      "@elizaos/core/*": ["../core/src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/eliza-livepeer-integration/packages/plugin-cognee/tsup.config.ts
+++ b/eliza-livepeer-integration/packages/plugin-cognee/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  tsconfig: './tsconfig.build.json',
+  sourcemap: true,
+  clean: true,
+  format: ['esm'],
+  dts: false,
+  external: [
+    'dotenv',
+    'fs',
+    'path',
+    'https',
+    'http',
+    'undici',
+    '@elizaos/core',
+  ],
+});

--- a/eliza-livepeer-integration/packages/plugin-cognee/vitest.config.ts
+++ b/eliza-livepeer-integration/packages/plugin-cognee/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest config and test coverage for Cognee plugin
- expose test scripts and Vitest dev dependency

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68459a1b21a08333ac07b79cf2bee5cb