### PR TITLE
Add Ollama AutoGen demo agent

### DIFF
--- a/autogen-agent/README.md
+++ b/autogen-agent/README.md
@@ -15,3 +15,16 @@ implementation.
 ```bash
 python -m autogen_agent.main
 ```
+
+### Using Ollama with AutoGen
+
+To try a simple chat powered by a local Ollama model, install the required
+packages and run the demo script:
+
+```bash
+pip install -r requirements.txt autogen ollama fix-busted-json
+python -m autogen_agent.ollama_demo
+```
+
+Set the `OLLAMA_MODEL` and `OLLAMA_API_ENDPOINT` environment variables to
+control which model and server are used.

--- a/autogen-agent/autogen_agent/ollama_demo.py
+++ b/autogen-agent/autogen_agent/ollama_demo.py
@@ -1,0 +1,27 @@
+import os
+import autogen
+
+
+def main() -> None:
+    """Run a simple AutoGen chat using an Ollama model."""
+    model = os.getenv("OLLAMA_MODEL", "llama3.2:3b")
+    endpoint = os.getenv("OLLAMA_API_ENDPOINT", "http://localhost:11434")
+
+    llm_config = {
+        "config_list": [
+            {
+                "api_type": "ollama",
+                "model": model,
+                "client_host": endpoint,
+            }
+        ]
+    }
+
+    assistant = autogen.AssistantAgent("assistant", llm_config=llm_config)
+    user = autogen.UserProxyAgent("user", human_input_mode="ALWAYS")
+
+    assistant.initiate_chat(user, message="Hello! How can I help you today?")
+
+
+if __name__ == "__main__":
+    main()

--- a/autogen-agent/requirements.txt
+++ b/autogen-agent/requirements.txt
@@ -2,3 +2,6 @@ redis>=5.0
 requests>=2.0
 fastapi>=0.111
 uvicorn>=0.29
+autogen>=0.9
+ollama>=0.1
+fix-busted-json>=0.0.7


### PR DESCRIPTION
## Summary
- implement `ollama_demo.py` for a simple AutoGen conversation using Ollama
- update README with instructions on running the demo
- extend requirements with autogen, ollama and fix-busted-json

## Testing
- `PYTHONPATH=$PWD/autogen-agent pytest autogen-agent/tests/test_main.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684823308c6083339ee2ef777965b9df