### PR TITLE
feat: Consolidate auto-updater into main cluster for simplified onboarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,45 @@ services:
     depends_on:
       - orchestrator
 
+  # Update Orchestrator - Auto-rebuild on code changes
+  update_orchestrator:
+    image: python:3.11-alpine
+    container_name: update_orchestrator
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../:/workspace  # Mount parent directory to access the repo
+      - ./update-orchestrator/state:/state
+      - ~/.ssh:/root/.ssh:ro
+    environment:
+      - UPDATE_MODE=${UPDATE_MODE:-dual}
+      - CHECK_INTERVAL=${CHECK_INTERVAL:-60}  # 1 minute for testing
+      - AUTO_APPROVE=${AUTO_APPROVE:-true}  # Auto-rebuild on changes
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
+      - REPO_PATH=/workspace
+      - SUBMODULE_PATH=/workspace/autonomy
+      - STATE_DIR=/state
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    command: |
+      sh -c "
+      apk add --no-cache git docker-cli docker-compose curl bash jq &&
+      pip install pyyaml requests &&
+      git config --global --add safe.directory /workspace &&
+      git config --global --add safe.directory /workspace/autonomy &&
+      while true; do
+        echo '[Update Check] '$(date);
+        python /workspace/scripts/dual_update_manager.py --repo-path /workspace $([ \"\$$AUTO_APPROVE\" = \"true\" ] && echo \"--auto\") || echo 'Update check failed';
+        echo '{\"last_check\": \"'$(date -Iseconds)'\"}' > /state/last_check.json;
+        echo '[Sleep] Waiting \$$CHECK_INTERVAL seconds...';
+        sleep \$$CHECK_INTERVAL;
+      done
+      "
+    restart: unless-stopped
+    networks:
+      - vtuber_network
+    labels:
+      - "com.centurylinklabs.watchtower.enable=false"  # Don't update the updater
+
   # ===========================================
   # LIVEPEER BYOC SERVICES
   # ===========================================


### PR DESCRIPTION
## Summary
- Integrated update_orchestrator service directly into main docker-compose.yml
- Set CHECK_INTERVAL to 60 seconds for testing (will monitor if auto-update triggers)
- Enabled AUTO_APPROVE=true for automatic rebuilds when changes are detected

## Benefits
- **Simpler onboarding**: Remote orchestrators just run `docker-compose up -d`
- **No separate configuration**: Everything in one place
- **Automatic updates**: Checks every minute and rebuilds when needed
- **Unified cluster**: All services managed together

## Testing
After merging, the auto-updater should:
1. Detect the changes within 60 seconds
2. Pull the latest code
3. Rebuild affected containers automatically
4. Log the update process

This PR tests the auto-update mechanism itself!