### PR TITLE
Add storage service for capture uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ backend issues an on-chain transfer using the configured wallet.
 
 Prefer AWS automation? See [docs/aws-onboarding.md](docs/aws-onboarding.md) for the EC2 provisioning workflow.
 
+Need to retain recordings? The storage pipeline is documented in [docs/capture-storage.md](docs/capture-storage.md).
+
 ## Registry & top-100 checks
 On startup the backend records orchestrator metadata under
 `backend/data/registry.json`. When `TOP_CONTRACT_*` variables are configured, it

--- a/docs/capture-storage.md
+++ b/docs/capture-storage.md
@@ -1,0 +1,47 @@
+# Capture Storage Pipeline
+
+This guide describes how to collect Pixel Streaming captures from orchestrator hosts and push them into the storage unit (formerly the `private_creator` box).
+
+## Components
+
+- **Storage service** (`storage_service/app.py`): a small FastAPI app that accepts WebM uploads and stores them under `captures/<orchestrator>/<session>/<timestamp>.webm`.
+- **Uploader script** (`scripts/upload_capture.py`): CLI helper that orchestrator jobs can call after generating a recording.
+
+## Running the storage service
+
+```sh
+# on the storage unit EC2
+cd autonomy
+python -m venv .venv
+source .venv/bin/activate
+pip install -r storage_service/requirements.txt
+STORAGE_SERVICE_ROOT=/data/captures \
+STORAGE_SERVICE_TOKEN=supersecret \
+python -m storage_service
+```
+
+By default the service listens on `0.0.0.0:9000`. Set `STORAGE_SERVICE_PORT` if you need a different port.
+
+## Uploading from an orchestrator
+
+1. Record the session (for example using the Playwright recorder container).
+2. Run the uploader:
+
+```sh
+python scripts/upload_capture.py \
+    /path/to/capture/webm \
+    session-20250927 \
+    http://storage-unit:9000 \
+    --orchestrator-id orch-alpha \
+    --token supersecret
+```
+
+The script prints the JSON response indicating where the file was stored.
+
+## API quick reference
+
+- `POST /api/captures` – upload a file (`multipart/form-data` with `file`, `session_id`, optional `orchestrator_id`).
+- `GET /api/captures` – list stored captures (optional `orchestrator_id` query).
+- `GET /api/captures/{orchestrator}/{session}/{filename}` – download an individual capture.
+
+Include the `X-Storage-Token` header when `STORAGE_SERVICE_TOKEN` is set.

--- a/orchestrator.env.example
+++ b/orchestrator.env.example
@@ -22,3 +22,9 @@ ENABLE_REST_API=0
 # ---------------------------------
 # ORCHESTRATOR_CONTACT_EMAIL=ops@example.com
 # ORCHESTRATOR_CAPABILITY=vtuber
+
+# ---------------------------------
+# Storage unit (optional)
+# ---------------------------------
+# STORAGE_UPLOAD_URL=http://storage-unit:9000
+# STORAGE_UPLOAD_TOKEN=supersecret

--- a/scripts/upload_capture.py
+++ b/scripts/upload_capture.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+
+def upload(
+    file_path: Path,
+    storage_url: str,
+    session_id: str,
+    orchestrator_id: Optional[str] = None,
+    token: Optional[str] = None,
+) -> None:
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+
+    headers = {"X-Storage-Token": token} if token else {}
+    with file_path.open("rb") as fh:
+        files = {"file": (file_path.name, fh, "video/webm")}
+        data = {"session_id": session_id}
+        if orchestrator_id:
+            data["orchestrator_id"] = orchestrator_id
+        resp = requests.post(f"{storage_url.rstrip('/')}/api/captures", files=files, data=data, headers=headers, timeout=60)
+        resp.raise_for_status()
+        print(resp.json())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upload a capture to the storage service")
+    parser.add_argument("file", type=Path)
+    parser.add_argument("session_id")
+    parser.add_argument("storage_url")
+    parser.add_argument("--orchestrator-id")
+    parser.add_argument("--token")
+    args = parser.parse_args()
+
+    upload(args.file, args.storage_url, args.session_id, args.orchestrator_id, args.token)
+
+
+if __name__ == "__main__":
+    main()

--- a/storage_service/__main__.py
+++ b/storage_service/__main__.py
@@ -1,0 +1,11 @@
+import os
+
+import uvicorn
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "storage_service.app:app",
+        host="0.0.0.0",
+        port=int(os.environ.get("STORAGE_SERVICE_PORT", "9000")),
+    )

--- a/storage_service/app.py
+++ b/storage_service/app.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, UploadFile
+from fastapi.responses import FileResponse, JSONResponse
+
+DEFAULT_STORAGE_ROOT = Path(os.environ.get("STORAGE_SERVICE_ROOT", "./captures"))
+DEFAULT_STORAGE_ROOT.mkdir(parents=True, exist_ok=True)
+
+API_TOKEN = os.environ.get("STORAGE_SERVICE_TOKEN")
+
+app = FastAPI(title="Autonomy Storage Service", version="1.0.0")
+
+
+def _check_token(x_storage_token: Optional[str] = Header(default=None)) -> None:
+    if API_TOKEN and x_storage_token != API_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid token")
+
+
+def _session_path(orchestrator_id: Optional[str], session_id: str) -> Path:
+    safe_session = session_id.replace("/", "_")
+    if orchestrator_id:
+        safe_orchestrator = orchestrator_id.replace("/", "_")
+        return DEFAULT_STORAGE_ROOT / safe_orchestrator / safe_session
+    return DEFAULT_STORAGE_ROOT / safe_session
+
+
+@app.post("/api/captures", dependencies=[Depends(_check_token)])
+async def upload_capture(
+    file: UploadFile = File(...),
+    session_id: str = Form(...),
+    orchestrator_id: Optional[str] = Form(default=None),
+) -> JSONResponse:
+    target_dir = _session_path(orchestrator_id, session_id)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    extension = Path(file.filename or "capture.webm").suffix or ".webm"
+    target_file = target_dir / f"{timestamp}{extension}"
+    with target_file.open("wb") as buffer:
+        content = await file.read()
+        buffer.write(content)
+    return JSONResponse(
+        {
+            "stored_path": str(target_file.resolve()),
+            "size": target_file.stat().st_size,
+        }
+    )
+
+
+@app.get("/api/captures", dependencies=[Depends(_check_token)])
+def list_captures(orchestrator_id: Optional[str] = None):
+    base = DEFAULT_STORAGE_ROOT
+    if orchestrator_id:
+        base = base / orchestrator_id
+    if not base.exists():
+        return []
+    results = []
+    for path in sorted(base.rglob("*")):
+        if path.is_file():
+            results.append(
+                {
+                    "path": str(path.relative_to(DEFAULT_STORAGE_ROOT)),
+                    "size": path.stat().st_size,
+                    "modified": datetime.utcfromtimestamp(path.stat().st_mtime).isoformat() + "Z",
+                }
+            )
+    return results
+
+
+@app.get("/api/captures/{orchestrator_id}/{session}/{filename}", dependencies=[Depends(_check_token)])
+def download_capture(orchestrator_id: str, session: str, filename: str) -> FileResponse:
+    path = DEFAULT_STORAGE_ROOT / orchestrator_id / session / filename
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="capture not found")
+    return FileResponse(path)

--- a/storage_service/requirements.txt
+++ b/storage_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a FastAPI storage service for WebM capture uploads with a CLI uploader, docs, and env config additions.
> 
> - **Storage service**:
>   - New FastAPI app in `storage_service/app.py` with token-protected endpoints: `POST /api/captures` (upload), `GET /api/captures` (list), `GET /api/captures/{orchestrator}/{session}/{filename}` (download).
>   - Stores uploads under `captures/<orchestrator>/<session>/<timestamp>.webm`; configurable via `STORAGE_SERVICE_ROOT` and `STORAGE_SERVICE_TOKEN`.
>   - Entrypoint `storage_service/__main__.py`; deps in `storage_service/requirements.txt`.
> - **Uploader**:
>   - New script `scripts/upload_capture.py` to POST WebM files to the storage service with optional `--orchestrator-id` and `--token`.
> - **Docs**:
>   - Add `docs/capture-storage.md` describing setup, usage, and API.
>   - README: link to storage pipeline docs.
> - **Config**:
>   - `orchestrator.env.example`: optional `STORAGE_UPLOAD_URL` and `STORAGE_UPLOAD_TOKEN` variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9afdbda2b2059ac7a4591c20bd3f4f09087c075b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->