### PR TITLE
Add payments address denylist enforcement

### DIFF
--- a/backend/payments/api.py
+++ b/backend/payments/api.py
@@ -89,6 +89,7 @@ class RegistrationResponse(BaseModel):
     balance_eth: str
     eligible_for_payments: bool
     is_top_100: bool
+    denylisted: bool
     registration_count: int
     cooldown_expires_at: Optional[str]
     message: str
@@ -100,6 +101,7 @@ class OrchestratorRecord(BaseModel):
     balance_eth: str
     eligible_for_payments: bool
     is_top_100: bool
+    denylisted: bool
     cooldown_expires_at: Optional[str]
     cooldown_active: bool
     first_seen: Optional[str]
@@ -192,6 +194,7 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
             balance_eth=str(balance),
             eligible_for_payments=result.eligible_for_payments,
             is_top_100=result.is_top_100,
+            denylisted=result.denylisted,
             registration_count=result.registration_count,
             cooldown_expires_at=result.cooldown_expires_at,
             message=result.message,
@@ -219,6 +222,7 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
                     balance_eth=str(balance),
                     eligible_for_payments=bool(record.get("eligible_for_payments", False)),
                     is_top_100=bool(record.get("is_top_100", False)),
+                    denylisted=bool(record.get("denylisted", False)),
                     cooldown_expires_at=cooldown_expires_at,
                     cooldown_active=cooldown_active,
                     first_seen=record.get("first_seen"),
@@ -262,6 +266,7 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
             balance_eth=str(balance),
             eligible_for_payments=bool(record.get("eligible_for_payments", False)),
             is_top_100=bool(record.get("is_top_100", False)),
+            denylisted=bool(record.get("denylisted", False)),
             cooldown_expires_at=cooldown_expires_at,
             cooldown_active=cooldown_active,
             first_seen=record.get("first_seen"),

--- a/backend/payments/config.py
+++ b/backend/payments/config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 from decimal import Decimal
 from pathlib import Path
 from typing import List, Optional
@@ -106,6 +107,7 @@ class PaymentSettings(BaseSettings):
     default_health_timeout: float = Field(default=5.0, env="PAYMENTS_DEFAULT_HEALTH_TIMEOUT")
     default_min_service_uptime: float = Field(default=80.0, env="PAYMENTS_DEFAULT_MIN_SERVICE_UPTIME")
     audit_log_path: Path = Field(default=Path("/app/data/audit/registry.log"), env="PAYMENTS_AUDIT_LOG_PATH")
+    address_denylist: List[str] = Field(default_factory=list, env="PAYMENTS_ADDRESS_DENYLIST")
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -156,8 +158,45 @@ class PaymentSettings(BaseSettings):
             raise ValueError("Value must be positive")
         return value
 
+    @field_validator("address_denylist", mode="before")
+    @classmethod
+    def parse_address_denylist(cls, value):  # type: ignore[override]
+        if value is None:
+            return []
+        if isinstance(value, str):
+            parts = re.split(r"[\s,]+", value.strip())
+            return [part for part in parts if part]
+        return value
+
+    @field_validator("address_denylist")
+    @classmethod
+    def normalize_address_denylist(cls, value: List[str]) -> List[str]:
+        normalized: List[str] = []
+        seen = set()
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError("address_denylist entries must be strings")
+            candidate = item.strip()
+            if not candidate:
+                continue
+            if not candidate.startswith("0x") or len(candidate) != 42:
+                raise ValueError("address_denylist entries must be 42-character hex strings")
+            candidate_lower = candidate.lower()
+            if not all(ch in "0123456789abcdef" for ch in candidate_lower[2:]):
+                raise ValueError("address_denylist entries must be valid hex strings")
+            if candidate_lower in seen:
+                continue
+            seen.add(candidate_lower)
+            normalized.append(candidate_lower)
+        return normalized
+
     @model_validator(mode="after")
-    def validate_single_orchestrator_mode(self) -> "PaymentSettings":
+    def populate_denylist_and_validate(self) -> "PaymentSettings":
+        if not self.address_denylist:
+            raw = os.environ.get("PAYMENTS_ADDRESS_DENYLIST")
+            if raw:
+                parts = self.parse_address_denylist(raw)
+                self.address_denylist = self.normalize_address_denylist(parts)
         if self.single_orchestrator_mode:
             if not self.orchestrator_id:
                 raise ValueError(

--- a/backend/payments/registry.py
+++ b/backend/payments/registry.py
@@ -35,6 +35,7 @@ class RegistrationResult:
     registration_count: int
     is_top_100: bool
     eligible_for_payments: bool
+    denylisted: bool
     has_active_payments: bool
     cooldown_expires_at: Optional[str]
     message: str
@@ -62,6 +63,10 @@ class Registry:
         self._lock = threading.RLock()
         self._records: Dict[str, Dict[str, Any]] = {}
         self._address_index: Dict[str, str] = {}
+        denylist_raw = getattr(settings, "address_denylist", []) or []
+        self._denylist_addresses: set[str] = {
+            address.lower() for address in denylist_raw if isinstance(address, str)
+        }
         self._load()
         self._top_cache_addresses: set[str] = set()
         self._top_cache_timestamp: Optional[datetime] = None
@@ -87,10 +92,17 @@ class Registry:
             if not isinstance(raw, dict):
                 continue
             record = self._normalize_record(orchestrator_id, raw, now_iso)
-            records[orchestrator_id] = record
             address = record.get("address")
+            denylisted = bool(record.get("denylisted", False))
             if isinstance(address, str):
-                address_index[address.lower()] = orchestrator_id
+                address_lower = address.lower()
+                if address_lower in self._denylist_addresses:
+                    denylisted = True
+                address_index[address_lower] = orchestrator_id
+            if denylisted:
+                record["denylisted"] = True
+                record["eligible_for_payments"] = False
+            records[orchestrator_id] = record
 
         self._records = records
         self._address_index = address_index
@@ -148,6 +160,7 @@ class Registry:
         normalized.setdefault("registration_count", int(record.get("registration_count", 0)))
         normalized.setdefault("is_top_100", bool(record.get("is_top_100", False)))
         normalized.setdefault("eligible_for_payments", bool(record.get("eligible_for_payments", False)))
+        normalized.setdefault("denylisted", bool(record.get("denylisted", False)))
         normalized.setdefault("cooldown_expires_at", record.get("cooldown_expires_at"))
         normalized.setdefault("last_missed_all_services", record.get("last_missed_all_services"))
         normalized.setdefault("last_cooldown_started_at", record.get("last_cooldown_started_at"))
@@ -225,6 +238,26 @@ class Registry:
             record = self._records.get(orchestrator_id)
             first_registration = record is None
 
+            if address_lower in self._denylist_addresses:
+                if record is not None:
+                    record["denylisted"] = True
+                    record["eligible_for_payments"] = False
+                    record["last_seen"] = now_iso
+                    self._records[orchestrator_id] = record
+                    self._persist()
+                self._write_audit_event(
+                    "register_denied",
+                    orchestrator_id,
+                    {
+                        "address": address,
+                        "reason": "denylisted",
+                    },
+                )
+                raise RegistryError(
+                    "Address is denylisted and cannot register",
+                    status_code=403,
+                )
+
             if not skip_rank_validation:
                 top_set = self._resolve_top_set()
                 if address_lower not in top_set:
@@ -253,6 +286,7 @@ class Registry:
                     "first_seen": now_iso,
                     "registration_count": 0,
                     "eligible_for_payments": True,
+                    "denylisted": False,
                 }
 
             previous_address = record.get("address")
@@ -309,7 +343,13 @@ class Registry:
             )
 
             cooldown_active = self._refresh_cooldown_state(record, now_dt)
-            record["eligible_for_payments"] = False if cooldown_active else bool(record.get("is_top_100", False))
+            denylisted_flag = bool(record.get("denylisted", False))
+            if denylisted_flag:
+                record["eligible_for_payments"] = False
+            else:
+                record["eligible_for_payments"] = (
+                    False if cooldown_active else bool(record.get("is_top_100", False))
+                )
 
             if metadata.get("services_healthy"):
                 record["last_healthy_at"] = now_iso
@@ -326,16 +366,19 @@ class Registry:
                 "first_registration": first_registration,
                 "registration_count": registration_count,
                 "is_top_100": is_top_member,
-                "eligible_for_payments": not cooldown_active and is_top_member,
+                "eligible_for_payments": not denylisted_flag and not cooldown_active and is_top_member,
+                "denylisted": denylisted_flag,
             },
         )
 
         message = "Registered orchestrator" if first_registration else "Registration refreshed"
-        if cooldown_active:
+        if denylisted_flag:
+            message = "Registration blocked (address denylisted)"
+        elif cooldown_active:
             message = f"{message} (cooldown active)"
 
         is_top_flag = bool(record.get("is_top_100", False))
-        eligible_flag = not cooldown_active and is_top_flag
+        eligible_flag = not denylisted_flag and not cooldown_active and is_top_flag
 
         return RegistrationResult(
             orchestrator_id=orchestrator_id,
@@ -344,6 +387,7 @@ class Registry:
             registration_count=registration_count,
             is_top_100=is_top_flag,
             eligible_for_payments=eligible_flag,
+            denylisted=denylisted_flag,
             has_active_payments=has_active_payments,
             cooldown_expires_at=record.get("cooldown_expires_at"),
             message=message,
@@ -356,8 +400,13 @@ class Registry:
                 return False
             now_dt = datetime.now(timezone.utc)
             cooldown_active = self._refresh_cooldown_state(record, now_dt)
+            denylisted_flag = bool(record.get("denylisted", False))
             changed = False
-            if cooldown_active:
+            if denylisted_flag:
+                if record.get("eligible_for_payments"):
+                    record["eligible_for_payments"] = False
+                    changed = True
+            elif cooldown_active:
                 if record.get("eligible_for_payments"):
                     record["eligible_for_payments"] = False
                     changed = True
@@ -368,7 +417,7 @@ class Registry:
                     changed = True
             if changed:
                 self._persist()
-            return bool(record.get("eligible_for_payments", False))
+            return bool(record.get("eligible_for_payments", False)) and not denylisted_flag
 
     def is_in_cooldown(self, orchestrator_id: str) -> bool:
         with self._lock:

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -28,6 +28,7 @@ def settings():
         top_contract_abi_path=None,
         registration_rate_limit_per_minute=5,
         registration_rate_limit_burst=5,
+        address_denylist=[],
     )
 
 
@@ -133,3 +134,40 @@ def test_address_uniqueness(temp_paths, settings):
                 address="0xAAAA",
             )
     assert exc.value.status_code == 409
+
+
+def test_registration_rejects_denylisted_address(temp_paths, settings):
+    balances_path, registry_path = temp_paths
+    settings.address_denylist = ["0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"]
+    registry = create_registry(registry_path, balances_path, settings)
+
+    with pytest.raises(RegistryError) as exc:
+        registry.register(
+            orchestrator_id="blocked",
+            address="0xDeadBeefDeadBeefDeadBeefDeadBeefDeadBeeF",
+            skip_rank_validation=True,
+        )
+
+    assert exc.value.status_code == 403
+    assert "denylisted" in str(exc.value)
+    assert registry.get_record("blocked") is None
+
+
+def test_existing_record_becomes_denylisted(temp_paths, settings):
+    balances_path, registry_path = temp_paths
+    settings.address_denylist = []
+    registry = create_registry(registry_path, balances_path, settings)
+
+    registry.register(
+        orchestrator_id="orch-keep",
+        address="0xAAAA",
+        skip_rank_validation=True,
+    )
+
+    settings.address_denylist = ["0xaaaa"]
+    reloaded = create_registry(registry_path, balances_path, settings)
+
+    record = reloaded.get_record("orch-keep")
+    assert record is not None
+    assert record["denylisted"] is True
+    assert reloaded.is_eligible("orch-keep") is False

--- a/docs/payments-deployment.md
+++ b/docs/payments-deployment.md
@@ -102,9 +102,12 @@ PAYMENTS_DEFAULT_MIN_SERVICE_UPTIME=80
 PAYMENTS_AUDIT_LOG_PATH=/app/data/audit/registry.log
 PAYMENTS_BOOTSTRAP_ORCHESTRATORS_PATH=/app/data/orchestrators.json
 PAYMENTS_BOOTSTRAP_SKIP_RANK_VALIDATION=true
+PAYMENTS_ADDRESS_DENYLIST=0xAddressOne,0xAddressTwo
 ```
 
 `PAYMENTS_SINGLE_ORCHESTRATOR_MODE` now defaults to `false`; if you turn it back on, also populate `ORCHESTRATOR_ID`, `ORCHESTRATOR_ADDRESS`, and (optionally) `ORCHESTRATOR_HEALTH_URL` so the backend can auto-register that single node. The recommended approach remains letting each orchestrator POST to the API.
+
+- `PAYMENTS_ADDRESS_DENYLIST` accepts a comma- or whitespace-separated list of 42-character payout wallet addresses. Any orchestrator that attempts to register using one of these addresses will receive a `403` and existing records will be held ineligible for payouts.
 
 ---
 
@@ -157,6 +160,9 @@ If an orchestrator’s public IP changes (e.g., instance restart without Elastic
 ---
 
 ## 6. Frequently Asked Questions
+
+**Q: How do I reset the registry but keep existing balances?**  
+A: Stop the payments backend (`docker compose -f backend/docker-compose.yml stop payments-backend`), back up `backend/data/balances.json`, and delete `backend/data/registry.json` (plus the `.bak` variant). When you restart the stack the ledger file is reused so outstanding balances remain intact, while the registry repopulates from fresh registrations. Configure `PAYMENTS_ADDRESS_DENYLIST` before restarting so denylisted wallets remain blocked from re-registering.
 
 **Q: How does the orchestrator know its public IP?**  
 A: The registration helper queries the EC2 metadata service. Override with `ORCHESTRATOR_HOST_PUBLIC_IP` if you are behind a load balancer or NAT gateway.


### PR DESCRIPTION
## Summary
- add `PAYMENTS_ADDRESS_DENYLIST` setting with parsing/validation and surface `denylisted` in API responses
- block new and existing orchestrators whose payout wallet is denylisted and persist audit trail updates
- document the env var and cover denylist flows with registry tests

## Testing
- pytest backend/tests/test_registry.py
