### PR TITLE
Restrict admin API to redact orchestrator IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ your provisioning pipeline. The script reads the standard `ORCHESTRATOR_*` varia
 - `GET /api/orchestrators` – returns the full registry including balances. Requires `X-Admin-Token` when
   `PAYMENTS_API_ADMIN_TOKEN` is set.
 - `GET /api/orchestrators/{id}` – single orchestrator view with cooldown timestamps and health markers.
+- Set `PAYMENTS_MANAGER_IP_ALLOWLIST` to the payments control-plane IP(s) so only trusted callers can view
+  sensitive metadata such as `host_public_ip`, `last_seen_ip`, and `health_url`; other clients receive the same
+  registry but with those fields redacted.
 
 ### Cooldown behaviour
 If all monitored containers are down three cycles in a row the backend pauses payouts for one hour. During this window

--- a/backend/payments/api.py
+++ b/backend/payments/api.py
@@ -1,6 +1,7 @@
 """HTTP API for orchestrator self-registration and admin visibility."""
 from __future__ import annotations
 
+import ipaddress
 import threading
 import time
 from collections import deque
@@ -138,6 +139,46 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
         window_seconds=10,
     )
 
+    manager_ip_allowlist = {
+        str(ipaddress.ip_address(ip)) for ip in getattr(settings, "manager_ip_allowlist", [])
+    }
+    sensitive_fields = {
+        "host_public_ip": None,
+        "last_seen_ip": None,
+        "health_url": None,
+    }
+
+    def normalize_ip(value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        try:
+            return str(ipaddress.ip_address(value))
+        except ValueError:
+            return None
+
+    def request_ip(request: Request) -> Optional[str]:
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            first = forwarded.split(",", 1)[0].strip()
+            normalized = normalize_ip(first)
+            if normalized:
+                return normalized
+        client_host = request.client.host if request.client else None
+        return normalize_ip(client_host)
+
+    def include_sensitive_fields(request: Request) -> bool:
+        if not manager_ip_allowlist:
+            return True
+        client = request_ip(request)
+        if client is None:
+            return False
+        return client in manager_ip_allowlist
+
+    def redact_record(record: OrchestratorRecord, include_sensitive: bool) -> OrchestratorRecord:
+        if include_sensitive:
+            return record
+        return record.model_copy(update=sensitive_fields)
+
     async def require_admin(request: Request) -> None:
         token = settings.api_admin_token
         if not token:
@@ -201,10 +242,13 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
         )
 
     @app.get("/api/orchestrators", response_model=OrchestratorsResponse)
-    async def list_orchestrators(_: Any = Depends(require_admin)) -> OrchestratorsResponse:
+    async def list_orchestrators(
+        request: Request, _: Any = Depends(require_admin)
+    ) -> OrchestratorsResponse:
         records = registry.all_records()
         response: List[OrchestratorRecord] = []
         now = datetime.now(timezone.utc)
+        sensitive_allowed = include_sensitive_fields(request)
         for orchestrator_id, record in records.items():
             balance = ledger.get_balance(orchestrator_id)
             cooldown_expires_at = record.get("cooldown_expires_at")
@@ -215,39 +259,40 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
                     cooldown_active = expires > now
                 except ValueError:
                     cooldown_active = False
-            response.append(
-                OrchestratorRecord(
-                    orchestrator_id=orchestrator_id,
-                    address=record.get("address", ""),
-                    balance_eth=str(balance),
-                    eligible_for_payments=bool(record.get("eligible_for_payments", False)),
-                    is_top_100=bool(record.get("is_top_100", False)),
-                    denylisted=bool(record.get("denylisted", False)),
-                    cooldown_expires_at=cooldown_expires_at,
-                    cooldown_active=cooldown_active,
-                    first_seen=record.get("first_seen"),
-                    last_seen=record.get("last_seen"),
-                    registration_count=int(record.get("registration_count", 0)),
-                    contact_email=record.get("contact_email"),
-                    capability=record.get("capability"),
-                    host_public_ip=record.get("host_public_ip"),
-                    host_name=record.get("host_name"),
-                    last_seen_ip=record.get("last_seen_ip"),
-                    last_missed_all_services=record.get("last_missed_all_services"),
-                    last_healthy_at=record.get("last_healthy_at"),
-                    last_cooldown_started_at=record.get("last_cooldown_started_at"),
-                    last_cooldown_cleared_at=record.get("last_cooldown_cleared_at"),
-                    health_url=record.get("health_url"),
-                    health_timeout=record.get("health_timeout"),
-                    monitored_services=record.get("monitored_services"),
-                    min_service_uptime=record.get("min_service_uptime"),
-                )
+            entry = OrchestratorRecord(
+                orchestrator_id=orchestrator_id,
+                address=record.get("address", ""),
+                balance_eth=str(balance),
+                eligible_for_payments=bool(record.get("eligible_for_payments", False)),
+                is_top_100=bool(record.get("is_top_100", False)),
+                denylisted=bool(record.get("denylisted", False)),
+                cooldown_expires_at=cooldown_expires_at,
+                cooldown_active=cooldown_active,
+                first_seen=record.get("first_seen"),
+                last_seen=record.get("last_seen"),
+                registration_count=int(record.get("registration_count", 0)),
+                contact_email=record.get("contact_email"),
+                capability=record.get("capability"),
+                host_public_ip=record.get("host_public_ip"),
+                host_name=record.get("host_name"),
+                last_seen_ip=record.get("last_seen_ip"),
+                last_missed_all_services=record.get("last_missed_all_services"),
+                last_healthy_at=record.get("last_healthy_at"),
+                last_cooldown_started_at=record.get("last_cooldown_started_at"),
+                last_cooldown_cleared_at=record.get("last_cooldown_cleared_at"),
+                health_url=record.get("health_url"),
+                health_timeout=record.get("health_timeout"),
+                monitored_services=record.get("monitored_services"),
+                min_service_uptime=record.get("min_service_uptime"),
             )
+            response.append(redact_record(entry, sensitive_allowed))
 
         return OrchestratorsResponse(orchestrators=response)
 
     @app.get("/api/orchestrators/{orchestrator_id}", response_model=OrchestratorRecord)
-    async def get_orchestrator(orchestrator_id: str, _: Any = Depends(require_admin)) -> OrchestratorRecord:
+    async def get_orchestrator(
+        orchestrator_id: str, request: Request, _: Any = Depends(require_admin)
+    ) -> OrchestratorRecord:
         record = registry.get_record(orchestrator_id)
         if not record:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
@@ -260,7 +305,7 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
                 cooldown_active = expires > datetime.now(timezone.utc)
             except ValueError:
                 cooldown_active = False
-        return OrchestratorRecord(
+        entry = OrchestratorRecord(
             orchestrator_id=orchestrator_id,
             address=record.get("address", ""),
             balance_eth=str(balance),
@@ -281,7 +326,12 @@ def create_app(registry: Registry, ledger: Ledger, settings: PaymentSettings) ->
             last_healthy_at=record.get("last_healthy_at"),
             last_cooldown_started_at=record.get("last_cooldown_started_at"),
             last_cooldown_cleared_at=record.get("last_cooldown_cleared_at"),
+            health_url=record.get("health_url"),
+            health_timeout=record.get("health_timeout"),
+            monitored_services=record.get("monitored_services"),
+            min_service_uptime=record.get("min_service_uptime"),
         )
+        return redact_record(entry, include_sensitive_fields(request))
 
     return app
 

--- a/backend/payments/config.py
+++ b/backend/payments/config.py
@@ -1,6 +1,7 @@
 """Settings loader for the payments backend."""
 from __future__ import annotations
 
+import ipaddress
 import os
 import re
 from decimal import Decimal
@@ -108,6 +109,10 @@ class PaymentSettings(BaseSettings):
     default_min_service_uptime: float = Field(default=80.0, env="PAYMENTS_DEFAULT_MIN_SERVICE_UPTIME")
     audit_log_path: Path = Field(default=Path("/app/data/audit/registry.log"), env="PAYMENTS_AUDIT_LOG_PATH")
     address_denylist: List[str] = Field(default_factory=list, env="PAYMENTS_ADDRESS_DENYLIST")
+    manager_ip_allowlist: List[str] = Field(
+        default_factory=list,
+        env="PAYMENTS_MANAGER_IP_ALLOWLIST",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -190,13 +195,49 @@ class PaymentSettings(BaseSettings):
             normalized.append(candidate_lower)
         return normalized
 
+    @field_validator("manager_ip_allowlist", mode="before")
+    @classmethod
+    def parse_manager_ip_allowlist(cls, value):  # type: ignore[override]
+        if value is None:
+            return []
+        if isinstance(value, str):
+            parts = re.split(r"[\s,]+", value.strip())
+            return [part for part in parts if part]
+        return value
+
+    @field_validator("manager_ip_allowlist")
+    @classmethod
+    def normalize_manager_ip_allowlist(cls, value: List[str]) -> List[str]:
+        normalized: List[str] = []
+        seen = set()
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError("manager_ip_allowlist entries must be strings")
+            candidate = item.strip()
+            if not candidate:
+                continue
+            try:
+                canonical = str(ipaddress.ip_address(candidate))
+            except ValueError as exc:
+                raise ValueError("manager_ip_allowlist entries must be valid IPv4/IPv6 addresses") from exc
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            normalized.append(canonical)
+        return normalized
+
     @model_validator(mode="after")
-    def populate_denylist_and_validate(self) -> "PaymentSettings":
+    def populate_lists_and_validate(self) -> "PaymentSettings":
         if not self.address_denylist:
             raw = os.environ.get("PAYMENTS_ADDRESS_DENYLIST")
             if raw:
                 parts = self.parse_address_denylist(raw)
                 self.address_denylist = self.normalize_address_denylist(parts)
+        if not self.manager_ip_allowlist:
+            raw_ips = os.environ.get("PAYMENTS_MANAGER_IP_ALLOWLIST")
+            if raw_ips:
+                parts = self.parse_manager_ip_allowlist(raw_ips)
+                self.manager_ip_allowlist = self.normalize_manager_ip_allowlist(parts)
         if self.single_orchestrator_mode:
             if not self.orchestrator_id:
                 raise ValueError(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -129,3 +129,87 @@ async def test_admin_listing_requires_token(temp_paths):
     assert authorized.status_code == 200
     data = authorized.json()
     assert data["orchestrators"][0]["orchestrator_id"] == "orch-admin"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_admin_listing_redacts_ips_for_unlisted_clients(temp_paths):
+    registry, ledger = build_registry(temp_paths)
+
+    address = "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+    metadata = {
+        "host_public_ip": "203.0.113.5",
+        "request_ip": "203.0.113.5",
+        "health_url": "http://203.0.113.5:9090/health",
+    }
+    with patch.object(Registry, "_resolve_top_set", return_value={address.lower()}):
+        registry.register(
+            orchestrator_id="orch-sanitize",
+            address=address,
+            metadata=metadata,
+        )
+
+    app_settings = SimpleNamespace(
+        registration_rate_limit_per_minute=5,
+        registration_rate_limit_burst=5,
+        api_admin_token="secret",
+        manager_ip_allowlist=["198.51.100.10"],
+    )
+    app = create_app(registry, ledger, app_settings)
+
+    blocked_transport = httpx.ASGITransport(app=app, client=("203.0.113.200", 12345))
+    async with httpx.AsyncClient(
+        transport=blocked_transport,
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/api/orchestrators",
+            headers={"X-Admin-Token": "secret"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    record = body["orchestrators"][0]
+    assert record["host_public_ip"] is None
+    assert record["last_seen_ip"] is None
+    assert record["health_url"] is None
+
+    allowed_transport = httpx.ASGITransport(app=app, client=("198.51.100.10", 4321))
+    async with httpx.AsyncClient(
+        transport=allowed_transport,
+        base_url="http://test",
+    ) as client:
+        allowed = await client.get(
+            "/api/orchestrators",
+            headers={"X-Admin-Token": "secret"},
+        )
+
+    assert allowed.status_code == 200
+    allowed_record = allowed.json()["orchestrators"][0]
+    assert allowed_record["host_public_ip"] == "203.0.113.5"
+    assert allowed_record["last_seen_ip"] == "203.0.113.5"
+    assert allowed_record["health_url"] == "http://203.0.113.5:9090/health"
+
+    async with httpx.AsyncClient(
+        transport=allowed_transport,
+        base_url="http://test",
+    ) as client:
+        allowed_single = await client.get(
+            "/api/orchestrators/orch-sanitize",
+            headers={"X-Admin-Token": "secret"},
+        )
+
+    assert allowed_single.status_code == 200
+    assert allowed_single.json()["host_public_ip"] == "203.0.113.5"
+
+    blocked_single_transport = httpx.ASGITransport(app=app, client=("192.0.2.44", 2222))
+    async with httpx.AsyncClient(
+        transport=blocked_single_transport,
+        base_url="http://test",
+    ) as client:
+        blocked_single = await client.get(
+            "/api/orchestrators/orch-sanitize",
+            headers={"X-Admin-Token": "secret"},
+        )
+
+    assert blocked_single.status_code == 200
+    assert blocked_single.json()["host_public_ip"] is None

--- a/docs/payments-deployment.md
+++ b/docs/payments-deployment.md
@@ -104,11 +104,13 @@ PAYMENTS_AUDIT_LOG_PATH=/app/data/audit/registry.log
 PAYMENTS_BOOTSTRAP_ORCHESTRATORS_PATH=/app/data/orchestrators.json
 PAYMENTS_BOOTSTRAP_SKIP_RANK_VALIDATION=true
 PAYMENTS_ADDRESS_DENYLIST=0xAddressOne,0xAddressTwo
+PAYMENTS_MANAGER_IP_ALLOWLIST=203.0.113.10,127.0.0.1
 ```
 
 `PAYMENTS_SINGLE_ORCHESTRATOR_MODE` now defaults to `false`; if you turn it back on, also populate `ORCHESTRATOR_ID`, `ORCHESTRATOR_ADDRESS`, and (optionally) `ORCHESTRATOR_HEALTH_URL` so the backend can auto-register that single node. The recommended approach remains letting each orchestrator POST to the API.
 
 - `PAYMENTS_ADDRESS_DENYLIST` accepts a comma- or whitespace-separated list of 42-character payout wallet addresses. Any orchestrator that attempts to register using one of these addresses will receive a `403` and existing records will be held ineligible for payouts.
+- `PAYMENTS_MANAGER_IP_ALLOWLIST` configures which source IPs are allowed to view orchestrator IP information (`host_public_ip`, `last_seen_ip`, `health_url`). Requests from any other address still receive the registry data, but the sensitive fields are redacted. Include the IP of the payments admin host (and any proxies that terminate TLS) here.
 
 ---
 


### PR DESCRIPTION
## Summary
- add  setting and validate IPv4/IPv6 values
- redact , ,  for admin API calls originating outside the allowlist
- document the new setting and cover allowlisted vs non-allowlisted access in tests

## Testing
- pytest backend/tests/test_api.py
- docker compose build payments-backend (on remote)
- curl against payments backend with/without X-Forwarded-For header
