### PR TITLE
docs: align system requirements with g4dn baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ it can be deployed and iterated on independently of the Unreal stack.
    cd Unreal_Vtuber
    ```
    :::note GPU reference
-   Our test environment runs on AWS g5.xlarge: NVIDIA A10G (24 GB VRAM, ~158 TFLOPS FP16, 150 W TDP), 4 vCPUs, 16 GB RAM. Any GPU with comparable specs should deliver similar Pixel Streaming quality.
+Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFLOPS FP16, 70 W TDP), 4 vCPUs, 16 GB RAM. Any GPU with comparable specs should deliver similar Pixel Streaming quality while keeping costs in check.
    :::
 2. Generate TURN credentials (writes `.env.turn`):
    ```bash

--- a/docs/aws-onboarding.md
+++ b/docs/aws-onboarding.md
@@ -23,7 +23,7 @@ This page is for operators who need to spin up a fresh Unreal orchestrator EC2 i
   - `CreateSecurityGroup`, `AuthorizeSecurityGroupIngress`
   - `CreateKeyPair`
   - `RunInstances`, `CreateTags`, `StopInstances`, `TerminateInstances`
-- These commands launch `g5.xlarge` instances, which are service-limited. Ask your AWS admin to grant your account access to the G5 family before running the script.
+- These commands launch `g4dn.xlarge` instances, which require NVIDIA T4 quotas. Ask your AWS admin to grant your account access to the G4 family before running the script.
 - Export the keys before provisioning (temporary example):
   ```bash
   export AWS_ACCESS_KEY_ID=AKIA...
@@ -81,7 +81,7 @@ python3 scripts/provision_orchestrator.py
 What happens:
 1. Key pair: creates or reuses the key pair named in `ORCHESTRATOR_KEY_NAME`.
 2. Security group: creates/updates the group `vtuber-orchestrator-autoprovision` with the correct ingress rules (8080/8888-8889/9876-9877 scoped to the dedicated client IP when provided; otherwise only the admin IP is allowed, and you should use SSH tunneling for UI access. TURN ports remain closed unless you opt in). TCP 9090 is opened to the payments backend IP, and port 22 stays limited to the admin IP (plus the dedicated IP if `ALLOW_DEDICATED_IP_SSH=true`).
-3. Instance: launches a `g5.xlarge` instance in `us-east-2`, subnet `subnet-0aad8738d8ac9fc25`, AMI `ami-0f09ef696435ff61a`, with a 200 GB gp3 root volume (override via `AWS_ROOT_VOLUME_GB`). If Elastic IP allocation is enabled it attaches the existing or newly created address automatically.
+3. Instance: launches a `g4dn.xlarge` instance in `us-east-2`, subnet `subnet-0aad8738d8ac9fc25`, AMI `ami-0f09ef696435ff61a`, with a 200 GB gp3 root volume (override via `AWS_ROOT_VOLUME_GB`). If Elastic IP allocation is enabled it attaches the existing or newly created address automatically.
 4. Bootstrapping: installs OS updates, Docker, NVIDIA driver + container toolkit, reboot, rsyncs `Unreal_Vtuber`, generates TURN credentials, pulls images, starts `docker-compose.unreal.yml`.
 5. Registration: runs `scripts/register_orchestrator.py` (with built-in retries) to register the orchestrator against `PAYMENTS_API_URL` with your ID/address (and contact email if set).
 6. Output: prints the instance ID, public IP, security group ID, and key path.
@@ -116,7 +116,7 @@ payouts to flow again.
 | Symptom | Likely Cause | Fix |
 |---------|--------------|-----|
 | Provision script fails with “UnauthorizedOperation” | IAM user lacks required permissions | Ask AWS admin to grant EC2 launch rights or use a role with broader access |
-| Launch fails: “g5.xlarge not available” | Account/region lacks G5 quota | File a limit-increase request for G5 instances in `us-east-2` |
+| Launch fails: “g4dn.xlarge not available” | Account/region lacks G4 quota | File a limit-increase request for G4 instances in `us-east-2` |
 | SSH times out | Security group doesn’t allow your IP | Re-run the script with correct `ADMIN_SOURCE_IP` (or enable `ALLOW_DEDICATED_IP_SSH`) |
 | Pixel Streaming not accessible from client | `DEDICATED_CLIENT_IP` incorrect | Update the env file and rerun provisioning or adjust the security group manually |
 | Payments API still paused | Payments backend left paused after earlier tests | `ssh ubuntu@3.141.111.200`, `cd payments-backend`, then `docker compose unpause payments-backend` |

--- a/docs/payments-deployment.md
+++ b/docs/payments-deployment.md
@@ -9,7 +9,7 @@ This document reflects the current production layout where the payments backend 
 ```
 +----------------------+              +----------------------+
 | Payments EC2         |<---health----|  Unreal Orchestrator |
-| (t3.small or similar)|              |  (g4/g5 instance)     |
+| (t3.small or similar)|              |  (g4dn.xlarge)       |
 |                      |----payouts-->|                      |
 | payments backend repo      |        | docker-compose.unreal|
 +----------------------+              +----------------------+

--- a/scripts/provision_orchestrator.env.example
+++ b/scripts/provision_orchestrator.env.example
@@ -2,7 +2,7 @@
 AWS_REGION=us-east-2
 #AWS_SUBNET_ID=subnet-0aad8738d8ac9fc25
 #AWS_AMI_ID=ami-0f09ef696435ff61a   # GPU-capable Ubuntu 22.04 AMI
-AWS_INSTANCE_TYPE=g5.xlarge
+AWS_INSTANCE_TYPE=g4dn.xlarge
 AWS_SECURITY_GROUP_NAME=vtuber-orchestrator-autoprovision
 ORCHESTRATOR_KEY_NAME=vtuber-orchestrator-key
 AWS_INSTANCE_NAME=vtuber-unreal-orchestrator-test


### PR DESCRIPTION
## Summary
- update Unreal_Vtuber docs to point at g4dn.xlarge (16 GB VRAM) as the standard GPU host
- refresh AWS onboarding and payments guides with the new instance type and quota notes
- change the provisioning .env example so new orchestrators launch on g4dn by default

## Testing
- documentation-only change