### PR TITLE
docs: clarify payments firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
    # edit .env with PAYMENTS_API_URL (point at the standalone backend),
    # ORCHESTRATOR_ID/ADDRESS, PUBLIC_IP, and ORCHESTRATOR_HEALTH_URL
    ```
-4. Open the firewall so the forwarder and payments backend can reach this host.
+4. Open the firewall so the forwarder (3.150.172.153) and payments backend (3.141.111.200) can reach this host.
 
 | Traffic source                     | Ports (TCP)                       | Ports (UDP)               |
 | --------------------------------- | ---------------------------------- | ------------------------- |
 | Forwarder / client (3.150.172.153) | 8080, 8888, 8889, 9876, 9877 | 3478, 49160‑49200 |
-| Payments backend (`<payments-ip>`) | 9090                          | –                |
+| Payments backend (3.141.111.200) | 9090                          | –                |
 
    **Example (UFW)**
    ```bash
    CLIENT_IP=3.150.172.153          # Forwarder public IP
-   PAYMENTS_IP=<payments-backend-ip>  # e.g., 10.0.0.15
+   PAYMENTS_IP=3.141.111.200        # Payments backend public IP
 
    for PORT in 8080 8888 8889 9876 9877; do
      sudo ufw allow from $CLIENT_IP to any port $PORT proto tcp


### PR DESCRIPTION
## Summary
- note the payments backend public IP (3.141.111.200) in the firewall table and example
- remove the lingering direct-viewer stanza so only the forwarder + payments backend rules remain

## Testing
- docs only