### PR TITLE
docs: mention allowed addresses env

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
    cp orchestrator.env.example .env
    # edit .env with PAYMENTS_API_URL (point at the standalone backend),
    # ORCHESTRATOR_ID/ADDRESS, PUBLIC_IP, and ORCHESTRATOR_HEALTH_URL
+   # include VTUBER_ALLOWED_ADDRESSES=3.150.172.153 so the script runner accepts commands from the forwarder
    ```
 4. Open the firewall so the forwarder (3.150.172.153) and payments backend (3.141.111.200) can reach this host.
 
@@ -55,7 +56,7 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
 
    sudo ufw reload
    ```
-5. Launch the Pixel Streaming stack (includes the health monitor service):
+5. Launch the Pixel Streaming stack (includes the health monitor service). Double-check `.env` still contains `VTUBER_ALLOWED_ADDRESSES=3.150.172.153` before running compose:
    ```bash
    docker network create vtuber_network 2>/dev/null || true
    docker compose -f docker-compose.unreal.yml up -d
@@ -88,7 +89,7 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
    ```bash
    docker compose -f docker-compose.unreal.yml pull
    ```
-4. **Recreate TURN + Unreal + signaling services with the new images**
+4. **Recreate TURN + Unreal + signaling services with the new images** (ensure `.env` still lists `VTUBER_ALLOWED_ADDRESSES=3.150.172.153` before restarting)
    ```bash
    docker compose -f docker-compose.unreal.yml up -d unreal-signaling unreal-game turn-server
    ```

--- a/docs/pixel-streaming-architecture.md
+++ b/docs/pixel-streaming-architecture.md
@@ -59,7 +59,7 @@ All services share the external Docker network `vtuber_network`, so the streamer
 2. `./scripts/generate_turn_credentials.sh`
 3. (Optional) `docker/aws-pixel-streaming/package-embody.sh /path/to/Embody/Linux`
 4. `docker compose -f docker-compose.unreal.yml build unreal-signaling`
-5. `docker compose -f docker-compose.unreal.yml up -d unreal-signaling unreal-game turn-server`
+5. (Ensure `.env` includes `VTUBER_ALLOWED_ADDRESSES=3.150.172.153`, then) `docker compose -f docker-compose.unreal.yml up -d unreal-signaling unreal-game turn-server`
 6. Verify logs and ulimit: `docker logs vtuber-unreal-signaling --tail 20`, `docker exec vtuber-unreal-game bash -lc 'ulimit -n'`
 7. Connect via browser on the orchestrator (`http://127.0.0.1:8080`, or tunnel the port over SSH if you need to view it remotely)
 


### PR DESCRIPTION
## Summary
- remind operators to set `VTUBER_ALLOWED_ADDRESSES=3.150.172.153` in `.env`
- note this requirement before both compose commands (initial launch + upgrade runbook)
- echo the same instruction in the Pixel Streaming architecture checklist so all docs stay aligned

## Testing
- docs only
