### PR TITLE
Docs: GHCR auth + Unreal VTuber EULA

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ variables, and data layout.
 ## License and allowed use
 
 The Unreal VTuber Pixel Streaming stack, including the packaged Unreal game
-container and pixel streaming containers, is proprietary to **Atumera Inc.** and
+container and pixel streaming containers, is proprietary to **Atumera LLC** and
 licensed for use only by authorized orchestrators under Atumera’s terms.
 
 - You may not reverse engineer, decompile, redistribute, or repurpose the game

--- a/legal/UNREAL_VTUBER_EULA.md
+++ b/legal/UNREAL_VTUBER_EULA.md
@@ -3,7 +3,7 @@
 _Last updated: 2025‑12‑02_
 
 These terms govern your use of the proprietary Unreal VTuber Pixel Streaming
-stack authored and operated by **Atumera Inc.** (“**Atumera**”, “**we**”, “**us**”).
+stack authored and operated by **Atumera LLC** (“**Atumera**”, “**we**”, “**us**”).
 By building, pulling, running, or otherwise using the container images and
 scripts described in this repository, you agree to be bound by these terms.
 
@@ -219,4 +219,3 @@ cases, these limitations apply to the maximum extent permitted by law.
 
 If you are negotiating a broader commercial or partner agreement with Atumera,
 that agreement will govern to the extent it conflicts with this EULA.
-


### PR DESCRIPTION
- Add GHCR auth steps to new deployments and upgrades.\n- Introduce legal/UNREAL_VTUBER_EULA.md describing Atumera’s proprietary license for the game + pixel streaming containers.\n- Add README section clarifying that the Unreal VTuber stack is proprietary, disallows reverse engineering/redistribution, and is licensed only for authorized orchestrator use.