### PR TITLE
docs: instruct using provided read-only PAT for repo + GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,12 @@ separate repository.
 ## New deployment
 
 1. Authenticate to GitHub and GHCR first (repo is private; images are private).
-   - Ensure your GitHub account is a collaborator on the repo/registry.
-   - If you already use `gh` on this host:
+   - Use the read-only PAT we provide to you out-of-band (scopes: `repo`, `read:packages`).
+   - Apply it for git and GHCR (replace `<PAT>` and `<github-username>`):
      ```bash
-     gh auth status || gh auth login --web --scopes "repo,read:packages"
-     gh auth token | docker login ghcr.io -u your-github-username --password-stdin
+     git config --global url."https://<PAT>@github.com/".insteadOf "https://github.com/"
+     echo '<PAT>' | docker login ghcr.io -u <github-username> --password-stdin
      ```
-   - If you prefer a PAT directly:
-     - Create a PAT on your own account with `repo` and `read:packages` (add `write:packages` only if you need to push images).
-     - Use it for both git and GHCR:
-       ```bash
-       git config --global url."https://<PAT>@github.com/".insteadOf "https://github.com/"
-       echo '<PAT>' | docker login ghcr.io -u your-github-username --password-stdin
-       ```
      The `docker login` writes `/home/ubuntu/.docker/config.json`, which is mounted into
      `vtuber-auto-updater` so Watchtower can keep pulling private images automatically.
 2. Clone the repo and enter it:
@@ -147,16 +140,11 @@ variables, and data layout.
 
 1. **Authenticate to GitHub + GHCR (private repo, private images)**  
    Do this on the host so Watchtower can reuse `/home/ubuntu/.docker/config.json`:
-   - Be sure the account is a collaborator on the repo/registry.
-   - With `gh`:
-     ```bash
-     gh auth status || gh auth login --web --scopes "repo,read:packages"
-     gh auth token | docker login ghcr.io -u your-github-username --password-stdin
-     ```
-   - Or with a PAT you created (scopes: `repo`, `read:packages`; add `write:packages` only if you push):
+   - Use the read-only PAT we provide to you out-of-band (scopes: `repo`, `read:packages`).
+   - Apply it for git and GHCR (replace `<PAT>` and `<github-username>`):
      ```bash
      git config --global url."https://<PAT>@github.com/".insteadOf "https://github.com/"
-     echo '<PAT>' | docker login ghcr.io -u your-github-username --password-stdin
+     echo '<PAT>' | docker login ghcr.io -u <github-username> --password-stdin
      ```
 2. **Pull the latest codebase**
    ```bash


### PR DESCRIPTION
replace the dual auth token options with single pat only option