### PR TITLE
TURN creds: preserve SIGNALING_EXTRA_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,24 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
    ```bash
    ./scripts/generate_turn_credentials.sh
    ```
-3. Copy and edit the orchestrator env:
+3. Configure matchmaker registration (required if using the edge/gateway `ps-gateway`):
+
+   Edit `.env.turn` and set `SIGNALING_EXTRA_ARGS`:
+   ```bash
+   SIGNALING_EXTRA_ARGS=--use_matchmaker --matchmaker_address ps-ca.embody.zone --matchmaker_port 8889 --public_ip <YOUR_PUBLIC_IP> --public_port 8080
+   ```
+
+   Notes:
+   - `./scripts/generate_turn_credentials.sh` preserves an existing `SIGNALING_EXTRA_ARGS=` line in `.env.turn`.
+   - Use the matchmaker host/port for your target edge (e.g. `3.128.159.66:8889`).
+4. Copy and edit the orchestrator env:
    ```bash
    cp orchestrator.env.example .env
    # edit .env with PAYMENTS_API_URL (point at the standalone backend),
    # ORCHESTRATOR_ID/ADDRESS, PUBLIC_IP, and ORCHESTRATOR_HEALTH_URL
    # include VTUBER_ALLOWED_ADDRESSES=3.150.172.153 so the script runner accepts commands from the forwarder
    ```
-4. Open the firewall so the forwarder (3.150.172.153) and payments backend (3.141.111.200) can reach this host.
+5. Open the firewall so the forwarder (3.150.172.153) and payments backend (3.141.111.200) can reach this host.
 
 | Traffic source                     | Ports (TCP)                       | Ports (UDP)               |
 | --------------------------------- | ---------------------------------- | ------------------------- |

--- a/scripts/generate_turn_credentials.sh
+++ b/scripts/generate_turn_credentials.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="${REPO_ROOT}/.env.turn"
 
+# Preserve signaling args if the env file already exists (the TURN script should not wipe matchmaker config).
+EXISTING_SIGNALING_EXTRA_ARGS=""
+if [[ -f "${ENV_FILE}" ]]; then
+  EXISTING_SIGNALING_EXTRA_ARGS="$(grep -E '^SIGNALING_EXTRA_ARGS=' "${ENV_FILE}" | head -n 1 | sed 's/^SIGNALING_EXTRA_ARGS=//')"
+fi
+SIGNALING_EXTRA_ARGS="${SIGNALING_EXTRA_ARGS:-${EXISTING_SIGNALING_EXTRA_ARGS}}"
+
 # Allow overriding the realm, otherwise default
 TURN_REALM=${TURN_REALM:-pixel-streaming}
 MIN_PORT=${TURN_MIN_PORT:-49160}
@@ -46,7 +53,7 @@ TURN_MIN_PORT=${MIN_PORT}
 TURN_MAX_PORT=${MAX_PORT}
 TURN_PORT=${PORT}
 TURN_SERVER=${TURN_EXTERNAL_IP:-${PUBLIC_IP}}:${PORT}
-TURN_PORT=${PORT}
+SIGNALING_EXTRA_ARGS=${SIGNALING_EXTRA_ARGS}
 EOF_ENV
 
 chmod 600 "${ENV_FILE}"


### PR DESCRIPTION
When rerunning `scripts/generate_turn_credentials.sh`, we were overwriting `.env.turn` and accidentally wiping `SIGNALING_EXTRA_ARGS` (matchmaker registration).

- Preserve existing `SIGNALING_EXTRA_ARGS=` from `.env.turn` (or allow overriding via env var)
- README: document where to set `SIGNALING_EXTRA_ARGS` for `ps-gateway`/matchmaker deployments
