### PR TITLE
tools: fix rollout.sh awk compatibility

### DIFF
--- a/tools/encrypted-game-image/rollout.sh
+++ b/tools/encrypted-game-image/rollout.sh
@@ -129,14 +129,14 @@ fi
 
 detect_game_image_from_compose() {
   awk '
-    /^[[:space:]]*unreal-game:[[:space:]]*$/ { in=1; next }
-    in && /^[[:space:]]*image:[[:space:]]*/ {
+    /^[[:space:]]*unreal-game:[[:space:]]*$/ { in_game=1; next }
+    in_game && /^[[:space:]]*image:[[:space:]]*/ {
       sub(/^[[:space:]]*image:[[:space:]]*/, "", $0)
       gsub(/[[:space:]]+$/, "", $0)
       print $0
       exit
     }
-    in && /^[^[:space:]]/ { in=0 }
+    in_game && /^[^[:space:]]/ { in_game=0 }
   ' "$1"
 }
 


### PR DESCRIPTION
Fixes orchestrator-side encrypted game rollout helper on hosts that ship an awk that treats `in` as a reserved keyword.

- `tools/encrypted-game-image/rollout.sh` used `awk` variable name `in`, causing syntax errors and preventing auto-detection of the game image from `docker-compose.unreal.yml`.
- Rename the awk state variable to `in_game`.

This unblocks the clean-room “stop → rm local tag → consume encrypted artifact → restart” test on orch hosts.
