### PR TITLE
Docs: clarify encrypted game image refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
 
 - `ghcr.io/its-define/unreal_vtuber/embody-signaling:latest` is an “app bundle” image (it runs the SignallingWebServer plus a runner and recorder-control process under `supervisord`).
 - The compose file still references the game image as `ghcr.io/its-define/unreal_vtuber/embody-ue-ps:latest`, but under the encrypted distribution flow this is just the **local tag** created by `docker load` (the game image is not pulled from GHCR).
+- If you can pull a proprietary game image from GHCR, that is a mistake — the game should only be distributed as an encrypted artifact (e.g. S3 `.tar.zst.age`) and loaded locally.
 - The default `docker-compose.unreal.yml` still runs `vtuber-script-runner` + `recorder-control` as separate containers because the Unreal command port binds to `127.0.0.1` inside `vtuber-unreal-game` and recordings need a mounted `/recordings` volume.
 - Service images (`vtuber-script-runner`, `recorder-control`, `orchestrator-health`, `vtuber-watchdog`, `orchestrator-registration`) are published under GHCR with `:latest` and `:sha-<gitsha>` tags; set `EMBODY_SERVICE_IMAGE_TAG=sha-…` in `.env` to pin them.
 

--- a/tools/encrypted-game-image/README.md
+++ b/tools/encrypted-game-image/README.md
@@ -18,6 +18,10 @@ curl <artifact-url> | age --decrypt -i <identity> | zstd -d | docker load
 
 The `secret_b64` returned by `POST /api/licenses/lease` is expected to be **base64(identity-file-bytes)**.
 
+Important:
+- `--image-ref` is a **Payments license identifier** (a string key). It does **not** need to exist as a Docker image in any registry.
+- The proprietary game image should **not** be published to GHCR; orchestrators load it only from the encrypted artifact URL.
+
 ## Dependencies
 
 - Producer: `docker`, `zstd`, `age`


### PR DESCRIPTION
Clarifies that `--image-ref` is a Payments license identifier (not a registry requirement) and that the proprietary game image should not be published/pulled from GHCR; orchestrators load it only from the encrypted artifact flow.