### PR TITLE
Orchestrator registration: allow disabling health_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ separate repository.
 ## Contents
 
 - `docker-compose.unreal.yml` – TURN, signaling, packaged Unreal container, script runner, orchestrator registration helper, and local health monitor.
-- `orchestrator-health/` – lightweight FastAPI service that exposes container health at `http://<host>:9090/health`.
+- `orchestrator-health/` – lightweight FastAPI service that exposes power control at `http://<host>:9090/power` (and optionally health at `/health`).
 - `pixel-streaming/` – Pixel Streaming configuration overrides shipped with the Unreal build.
 - `tools/encrypted-game-image/` – helper scripts to distribute the proprietary game image as an encrypted artifact (no GHCR creds needed on the orchestrator).
 - `tools/recorder/` – recorder-control sidecar (see `docs/recorder-control.md`).
@@ -93,7 +93,8 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
    ```bash
    cp orchestrator.env.example .env
    # edit .env with PAYMENTS_API_URL (point at the standalone backend),
-   # ORCHESTRATOR_ID/ADDRESS, PUBLIC_IP, and ORCHESTRATOR_HEALTH_URL
+   # ORCHESTRATOR_ID/ADDRESS and PUBLIC_IP
+   # (optional) set ORCHESTRATOR_HEALTH_URL unless you run a forwarder-side watcher and set ORCHESTRATOR_DISABLE_HEALTH_URL=1
    # include VTUBER_ALLOWED_ADDRESSES=3.150.172.153 so the script runner accepts commands from the forwarder
    ```
 4. Open the firewall so the forwarder (3.150.172.153) and payments backend (3.141.111.200) can reach this host.
@@ -101,12 +102,11 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
 | Traffic source                     | Ports (TCP)                       | Ports (UDP)               |
 | --------------------------------- | ---------------------------------- | ------------------------- |
 | Forwarder / client (3.150.172.153) | 8080, 8888, 8889, 9877 | 3478, 49160‑49200 |
-| Payments backend (3.141.111.200) | 9090                          | –                |
+| Forwarder / watcher (3.150.172.153) | 9090 (power API)                  | –                |
 
    **Example (UFW)**
    ```bash
    CLIENT_IP=3.150.172.153          # Forwarder public IP
-   PAYMENTS_IP=3.141.111.200        # Payments backend public IP
 
    for PORT in 8080 8888 8889 9877; do
      sudo ufw allow from $CLIENT_IP to any port $PORT proto tcp
@@ -114,7 +114,7 @@ Our test environment runs on AWS g4dn.xlarge: NVIDIA T4 (16 GB VRAM, ~65 TFL
    sudo ufw allow from $CLIENT_IP to any port 3478 proto udp
    sudo ufw allow from $CLIENT_IP to any port 49160:49200 proto udp
 
-   sudo ufw allow from $PAYMENTS_IP to any port 9090 proto tcp
+   sudo ufw allow from $CLIENT_IP to any port 9090 proto tcp
 
    sudo ufw reload
    ```
@@ -236,7 +236,7 @@ Repo and container images are public now—no GitHub auth or PAT needed to updat
    ```
 2. **Make sure allowlists match the new deployment**
    - Repeat the firewall steps from “New deployment” so the forwarder and payments backend can still reach the host.
-   - If the orchestrator’s public IP changed, refresh the allowlist and update `.env` (`PUBLIC_IP`, `ORCHESTRATOR_HEALTH_URL`).
+   - If the orchestrator’s public IP changed, refresh the allowlist and update `.env` (`PUBLIC_IP`, and optionally `ORCHESTRATOR_HEALTH_URL` unless using `ORCHESTRATOR_DISABLE_HEALTH_URL=1`).
 3. **Refresh non-game container images**
    ```bash
    docker compose -f docker-compose.unreal.yml pull \

--- a/docs/unreal-integration.md
+++ b/docs/unreal-integration.md
@@ -29,7 +29,8 @@ After the services come up in detached mode you should see:
 
 * Signaling health – `curl http://localhost:8080/healthz`
 * Unreal TCP loopback interface – reachable **inside** `vtuber-unreal-game` on `127.0.0.1:7777`
-* Orchestrator health endpoint – `http://localhost:9090/health` (surface status for the payments backend)
+* Orchestrator power endpoint – `http://localhost:9090/power` (used by forwarder automation to sleep/wake containers)
+* Orchestrator health endpoint – `http://localhost:9090/health` (optional; Payments can instead rely on forwarder-reported health)
 
 Use `./scripts/start_vtuber_unreal.sh ps` to confirm container status or `./scripts/start_vtuber_unreal.sh logs unreal-game` for tailing output.
 

--- a/orchestrator.env.example
+++ b/orchestrator.env.example
@@ -5,7 +5,10 @@ PAYMENTS_API_URL=http://3.141.111.200:8081
 ORCHESTRATOR_ID=orch-local-001
 ORCHESTRATOR_ADDRESS=0x0000000000000000000000000000000000000000
 ORCHESTRATOR_REGISTRATION_DELAY=10
-ORCHESTRATOR_HEALTH_URL=http://<PUBLIC_IP>:9090/health
+# If you run a forwarder-side health watcher that reports into Payments, you can omit health_url entirely:
+# ORCHESTRATOR_DISABLE_HEALTH_URL=1
+# Otherwise set a reachable health endpoint for Payments to poll:
+# ORCHESTRATOR_HEALTH_URL=http://<PUBLIC_IP>:9090/health
 MONITORED_SERVICES=vtuber-unreal-game,vtuber-unreal-signaling,vtuber-turn-server
 VTUBER_ALLOWED_ADDRESSES=
 VTUBER_SESSION_DIR=/home/ubuntu/vtuber_sessions  # change to a writable path on your host

--- a/scripts/register_orchestrator.py
+++ b/scripts/register_orchestrator.py
@@ -79,6 +79,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--host-public-ip", default=env_default("ORCHESTRATOR_HOST_PUBLIC_IP"), help="Optional public IP metadata")
     parser.add_argument("--health-url", default=env_default("ORCHESTRATOR_HEALTH_URL"), help="Optional override for the orchestrator health endpoint URL")
     parser.add_argument(
+        "--disable-health-url",
+        action="store_true",
+        default=env_default("ORCHESTRATOR_DISABLE_HEALTH_URL", "").strip().lower() in {"1", "true", "yes", "y", "on"},
+        help="Do not include health_url in the registration payload (use when a forwarder watcher reports health)",
+    )
+    parser.add_argument(
         "--health-port",
         type=int,
         default=int(env_default("ORCHESTRATOR_HEALTH_PORT", "9090")),
@@ -141,11 +147,12 @@ def build_payload(args: argparse.Namespace) -> Dict[str, Any]:
     if host_ip:
         payload["host_public_ip"] = host_ip
 
-    health_url = args.health_url
-    if not health_url and host_ip:
-        health_url = f"http://{host_ip}:{args.health_port}/health"
-    if health_url:
-        payload["health_url"] = health_url
+    if not args.disable_health_url:
+        health_url = args.health_url
+        if not health_url and host_ip:
+            health_url = f"http://{host_ip}:{args.health_port}/health"
+        if health_url:
+            payload["health_url"] = health_url
 
     if args.health_timeout is not None:
         payload["health_timeout"] = args.health_timeout


### PR DESCRIPTION
Adds a way to register an orchestrator without including `health_url` when a forwarder-side watcher is reporting health into Payments:

- `scripts/register_orchestrator.py`: new `--disable-health-url`
- `.env` support: `ORCHESTRATOR_DISABLE_HEALTH_URL=1`
- Docs/env example updates.
