### PR TITLE
CLI: run multiple Unreal VTuber instances

### DIFF
--- a/docker-compose.unreal.yml
+++ b/docker-compose.unreal.yml
@@ -7,10 +7,10 @@ services:
   # TURN server to relay WebRTC traffic when direct peer connections fail
   turn-server:
     image: ghcr.io/its-define/unreal_vtuber/embody-turn-server:latest
-    container_name: vtuber-turn-server
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-turn-server
     restart: unless-stopped
     env_file:
-      - .env.turn
+      - ${TURN_ENV_FILE:-.env.turn}
     entrypoint: ['/bin/sh', '-c']
     command: |
       turnserver \
@@ -37,20 +37,20 @@ services:
   # Signaling Server - WebRTC signaling (UI served from the edge/gateway)
   unreal-signaling:
     image: ghcr.io/its-define/unreal_vtuber/embody-signaling:latest
-    container_name: vtuber-unreal-signaling
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-signaling
     restart: unless-stopped
     depends_on:
       - turn-server
     env_file:
-      - .env.turn
+      - ${TURN_ENV_FILE:-.env.turn}
     ports:
-      - "8080:80"       # HTTP web interface
-      - "8888:8888"     # Streamer port
+      - "${SIGNALING_HTTP_HOST_PORT:-8080}:80"       # HTTP web interface
+      - "${SIGNALING_STREAMER_HOST_PORT:-8888}:8888" # Streamer port
     environment:
       PUBLIC_IP: ${PUBLIC_IP:-auto}
-      HTTP_PORT: "8080"
-      STREAMER_PORT: "8888"
-      SFU_PORT: "8889"
+      HTTP_PORT: "${SIGNALING_HTTP_HOST_PORT:-8080}"
+      STREAMER_PORT: "${SIGNALING_STREAMER_HOST_PORT:-8888}"
+      SFU_PORT: "${RECORDER_CTRL_HOST_PORT:-8889}"
       STUN_SERVER: ${STUN_SERVER:-stun.l.google.com:19302}
       # Optional additional Wilbur/start.sh CLI flags (example: matchmaker registration).
       SIGNALING_EXTRA_ARGS: ${SIGNALING_EXTRA_ARGS:-}
@@ -72,7 +72,7 @@ services:
   # Embody Game - Headless Unreal Engine with Pixel Streaming
   unreal-game:
     image: ghcr.io/its-define/unreal_vtuber/embody-ue-ps:latest
-    container_name: vtuber-unreal-game
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-game
     restart: unless-stopped
     runtime: nvidia
     ulimits:
@@ -80,8 +80,8 @@ services:
         soft: ${HOST_ULIMIT_NOFILE:-1040}
         hard: ${HOST_ULIMIT_NOFILE:-1040}
     ports:
-      - "7777:7777"
-      - "9877:9877"
+      - "${VTUBER_GAME_TCP_HOST_PORT:-7777}:7777"
+      - "${VTUBER_RUNNER_HOST_PORT:-9877}:9877"
     depends_on:
       unreal-signaling:
         condition: service_healthy
@@ -122,7 +122,7 @@ services:
 
   vtuber-script-runner:
     image: ghcr.io/its-define/unreal_vtuber/vtuber-script-runner:${EMBODY_SERVICE_IMAGE_TAG:-latest}
-    container_name: vtuber-script-runner
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-script-runner
     network_mode: "service:unreal-game"
     environment:
       - VTUBER_SESSION_ROOT=/opt/embody/sessions
@@ -137,25 +137,25 @@ services:
 
   vtuber-watchdog:
     image: ghcr.io/its-define/unreal_vtuber/vtuber-watchdog:${EMBODY_SERVICE_IMAGE_TAG:-latest}
-    container_name: vtuber-watchdog
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-watchdog
     restart: unless-stopped
     depends_on:
       - unreal-game
     environment:
       - WATCHDOG_COMPOSE_FILE=/workspace/docker-compose.unreal.yml
       - WATCHDOG_RUNNER_SERVICE=vtuber-script-runner
-      - WATCHDOG_GAME_CONTAINER=vtuber-unreal-game
+      - WATCHDOG_GAME_CONTAINER=${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-game
       - WATCHDOG_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-unreal_vtuber}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.unreal.yml:/workspace/docker-compose.unreal.yml:ro
       - ./.env:/workspace/.env:ro
-      - ./.env.turn:/workspace/.env.turn:ro
+      - ./${TURN_ENV_FILE:-.env.turn}:/workspace/.env.turn:ro
       - /var/lib/vtuber/power-state:/var/lib/vtuber/power-state:ro
 
   orchestrator-registration:
     image: ghcr.io/its-define/unreal_vtuber/orchestrator-registration:${EMBODY_SERVICE_IMAGE_TAG:-latest}
-    container_name: vtuber-orchestrator-registration
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-orchestrator-registration
     depends_on:
       - unreal-game
     env_file:
@@ -174,24 +174,24 @@ services:
 
   orchestrator-health:
     image: ghcr.io/its-define/unreal_vtuber/orchestrator-health:${EMBODY_SERVICE_IMAGE_TAG:-latest}
-    container_name: vtuber-orchestrator-health
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-orchestrator-health
     command: ["python", "-m", "orchestrator_health.remote_health_service"]
     environment:
-      - MONITORED_SERVICES=${MONITORED_SERVICES:-vtuber-unreal-game,vtuber-unreal-signaling,vtuber-turn-server}
+      - MONITORED_SERVICES=${MONITORED_SERVICES:-${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-game,${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-signaling,${VTUBER_CONTAINER_PREFIX:-vtuber}-turn-server}
       - ORCHESTRATOR_HEALTH_PORT=9090
       - POWER_ALLOWED_IPS=${POWER_ALLOWED_IPS:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/vtuber/power-state:/var/lib/vtuber/power-state
     ports:
-      - "9090:9090"
+      - "${ORCHESTRATOR_HEALTH_HOST_PORT:-9090}:9090"
     restart: unless-stopped
     networks:
       - vtuber_network
 
   vtuber-auto-updater:
     image: containrrr/watchtower:1.7.1
-    container_name: vtuber-auto-updater
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-auto-updater
     restart: unless-stopped
     depends_on:
       - unreal-game
@@ -207,29 +207,29 @@ services:
         "--cleanup",
         "--include-restarting",
         "--rolling-restart",
-        "vtuber-turn-server",
-        "vtuber-unreal-signaling",
-        "vtuber-script-runner",
-        "vtuber-recorder-control",
-        "vtuber-orchestrator-health",
-        "vtuber-watchdog",
+        "${VTUBER_CONTAINER_PREFIX:-vtuber}-turn-server",
+        "${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-signaling",
+        "${VTUBER_CONTAINER_PREFIX:-vtuber}-script-runner",
+        "${VTUBER_CONTAINER_PREFIX:-vtuber}-recorder-control",
+        "${VTUBER_CONTAINER_PREFIX:-vtuber}-orchestrator-health",
+        "${VTUBER_CONTAINER_PREFIX:-vtuber}-watchdog",
       ]
 
   recorder-control:
     image: ghcr.io/its-define/unreal_vtuber/recorder-control:${EMBODY_SERVICE_IMAGE_TAG:-latest}
-    container_name: vtuber-recorder-control
+    container_name: ${VTUBER_CONTAINER_PREFIX:-vtuber}-recorder-control
     depends_on:
       - unreal-signaling
     env_file:
-      - .env.turn
+      - ${TURN_ENV_FILE:-.env.turn}
     environment:
       - RECORDER_CTRL_PORT=8889
-      - RECORDER_SIGNALING_URL=${RECORDER_SIGNALING_URL:-ws://vtuber-unreal-signaling:80}
+      - RECORDER_SIGNALING_URL=${RECORDER_SIGNALING_URL:-ws://unreal-signaling:80}
       - RECORDER_OUTPUT_DIR=/recordings
       - PY_RECORDER_PATH=/opt/embody/recorder/gs_webrtc_recorder.py
       - VTUBER_ALLOWED_ADDRESSES=${VTUBER_ALLOWED_ADDRESSES:-127.0.0.1,::1,172.17.0.1,172.18.0.1}
       # Recorder connects on the docker network; default TURN host is the local coturn service.
-      - RECORDER_TURN_HOST=${RECORDER_TURN_HOST:-vtuber-turn-server}
+      - RECORDER_TURN_HOST=${RECORDER_TURN_HOST:-turn-server}
       - RECORDINGS_API_TOKEN=${RECORDINGS_API_TOKEN:-}
     volumes:
       - ${VTUBER_RECORDINGS_DIR:-/recordings}:/recordings
@@ -238,9 +238,9 @@ services:
     networks:
       - vtuber_network
     ports:
-      - "8889:8889"
+      - "${RECORDER_CTRL_HOST_PORT:-8889}:8889"
 
 networks:
   vtuber_network:
     external: true
-    name: vtuber_network
+    name: ${VTUBER_NETWORK_NAME:-vtuber_network}

--- a/docs/unreal-integration.md
+++ b/docs/unreal-integration.md
@@ -27,6 +27,12 @@ If the host has multiple GPUs, select one explicitly:
 ./scripts/start_vtuber_unreal.sh start --gpu 0 -d
 ```
 
+To run multiple stacks on one host (separate containers + docker network + offset ports), pass an instance id:
+
+```bash
+./scripts/start_vtuber_unreal.sh start --instance 2 -d
+```
+
 An orchestrator registration helper (`orchestrator-registration` service) now runs alongside the Unreal compose file. Configure `PAYMENTS_API_URL` plus the `ORCHESTRATOR_*` variables in `.env` so the helper can post to the payments backend when the stack boots. Start the backend independently from its dedicated repository. The helper retries with backoff for up to five minutes but exits cleanly even if the backend is unreachable.
 
 The helper script will:

--- a/scripts/generate_turn_credentials.sh
+++ b/scripts/generate_turn_credentials.sh
@@ -2,7 +2,29 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENV_FILE="${REPO_ROOT}/.env.turn"
+ENV_FILE="${TURN_ENV_FILE:-${REPO_ROOT}/.env.turn}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--output)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --output requires a file path." >&2
+        exit 1
+      fi
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--output <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$ENV_FILE" != /* ]]; then
+  ENV_FILE="${REPO_ROOT}/${ENV_FILE}"
+fi
 
 # Allow overriding the realm, otherwise default
 TURN_REALM=${TURN_REALM:-pixel-streaming}

--- a/scripts/start_vtuber_unreal.sh
+++ b/scripts/start_vtuber_unreal.sh
@@ -20,6 +20,20 @@ fi
 COMMAND="up"
 DETACHED=""
 GPU_SELECTION=""
+INSTANCE_ID=""
+PORT_OFFSET=""
+VTUBER_CONTAINER_PREFIX=""
+VTUBER_NETWORK_NAME=""
+TURN_ENV_FILE=""
+SIGNALING_HTTP_HOST_PORT=""
+SIGNALING_STREAMER_HOST_PORT=""
+RECORDER_CTRL_HOST_PORT=""
+ORCHESTRATOR_HEALTH_HOST_PORT=""
+VTUBER_GAME_TCP_HOST_PORT=""
+VTUBER_RUNNER_HOST_PORT=""
+TURN_PORT=""
+TURN_MIN_PORT=""
+TURN_MAX_PORT=""
 LOG_SERVICE=""
 
 print_help() {
@@ -39,10 +53,13 @@ print_help() {
     echo "Options:"
     echo "  -d, --detach              Run in detached mode (background)"
     echo "  --gpu <id|all|none>       Select which NVIDIA GPU to expose (sets NVIDIA_VISIBLE_DEVICES)"
+    echo "  --instance <id>           Run a separate stack instance (isolated containers + docker network)"
+    echo "  --port-offset <n>         Offset host ports to avoid collisions (default derived from --instance)"
     echo ""
     echo "Examples:"
     echo "  $0 start -d                # Start in background"
     echo "  $0 start --gpu 0 -d         # Start using GPU 0"
+    echo "  $0 start --instance 2 -d    # Start a second instance (auto port offsets)"
     echo "  $0 logs unreal-game         # Show game logs"
     echo "  $0 test                     # Trigger sample BYOB playback"
 }
@@ -51,6 +68,38 @@ while [ $# -gt 0 ]; do
     case "$1" in
         -d|--detach)
             DETACHED="-d"
+            shift
+            ;;
+        --instance)
+            if [ -z "${2:-}" ]; then
+                echo -e "${RED}Error: --instance requires a value (e.g. --instance 2).${NC}"
+                exit 1
+            fi
+            INSTANCE_ID="$2"
+            shift 2
+            ;;
+        --instance=*)
+            INSTANCE_ID="${1#*=}"
+            if [ -z "$INSTANCE_ID" ]; then
+                echo -e "${RED}Error: --instance requires a value (e.g. --instance=2).${NC}"
+                exit 1
+            fi
+            shift
+            ;;
+        --port-offset)
+            if [ -z "${2:-}" ]; then
+                echo -e "${RED}Error: --port-offset requires a numeric value (e.g. --port-offset 100).${NC}"
+                exit 1
+            fi
+            PORT_OFFSET="$2"
+            shift 2
+            ;;
+        --port-offset=*)
+            PORT_OFFSET="${1#*=}"
+            if [ -z "$PORT_OFFSET" ]; then
+                echo -e "${RED}Error: --port-offset requires a numeric value (e.g. --port-offset=100).${NC}"
+                exit 1
+            fi
             shift
             ;;
         --gpu)
@@ -90,12 +139,100 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-compose() {
-    if [ -n "$GPU_SELECTION" ]; then
-        NVIDIA_VISIBLE_DEVICES="$GPU_SELECTION" docker compose -f docker-compose.unreal.yml "$@"
-    else
-        docker compose -f docker-compose.unreal.yml "$@"
+normalize_instance() {
+    if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "1" ]; then
+        INSTANCE_ID=""
+        return
     fi
+    if ! echo "$INSTANCE_ID" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+        echo -e "${RED}Error: --instance must be alphanumeric (allowed: . _ -). Got: ${INSTANCE_ID}${NC}"
+        exit 1
+    fi
+}
+
+normalize_offset() {
+    if [ -n "$PORT_OFFSET" ] && ! echo "$PORT_OFFSET" | grep -Eq '^[0-9]+$'; then
+        echo -e "${RED}Error: --port-offset must be a non-negative integer. Got: ${PORT_OFFSET}${NC}"
+        exit 1
+    fi
+
+    if [ -z "$PORT_OFFSET" ]; then
+        if echo "${INSTANCE_ID:-}" | grep -Eq '^[0-9]+$'; then
+            # Instance 2 -> +100, instance 3 -> +200, ...
+            if [ "${INSTANCE_ID}" -ge 2 ]; then
+                PORT_OFFSET=$(( (INSTANCE_ID - 1) * 100 ))
+            else
+                PORT_OFFSET=0
+            fi
+        elif [ -n "$INSTANCE_ID" ]; then
+            PORT_OFFSET=100
+        else
+            PORT_OFFSET=0
+        fi
+    fi
+}
+
+derive_instance_env() {
+    if [ -n "$INSTANCE_ID" ]; then
+        VTUBER_CONTAINER_PREFIX="vtuber-${INSTANCE_ID}"
+        VTUBER_NETWORK_NAME="vtuber_network_${INSTANCE_ID}"
+        TURN_ENV_FILE=".env.turn.${INSTANCE_ID}"
+    else
+        VTUBER_CONTAINER_PREFIX=""
+        VTUBER_NETWORK_NAME=""
+        TURN_ENV_FILE=".env.turn"
+    fi
+
+    SIGNALING_HTTP_HOST_PORT=$((8080 + PORT_OFFSET))
+    SIGNALING_STREAMER_HOST_PORT=$((8888 + PORT_OFFSET))
+    RECORDER_CTRL_HOST_PORT=$((8889 + PORT_OFFSET))
+    ORCHESTRATOR_HEALTH_HOST_PORT=$((9090 + PORT_OFFSET))
+    VTUBER_GAME_TCP_HOST_PORT=$((7777 + PORT_OFFSET))
+    VTUBER_RUNNER_HOST_PORT=$((9877 + PORT_OFFSET))
+    TURN_PORT=$((3478 + PORT_OFFSET))
+
+    # TURN uses a port range; shift it farther to avoid collisions when PORT_OFFSET is small.
+    local turn_range_offset
+    turn_range_offset=$((PORT_OFFSET * 10))
+    TURN_MIN_PORT=$((49160 + turn_range_offset))
+    TURN_MAX_PORT=$((49200 + turn_range_offset))
+
+    if [ "$TURN_MAX_PORT" -gt 65535 ] || [ "$TURN_PORT" -gt 65535 ]; then
+        echo -e "${RED}Error: derived TURN ports exceed 65535 (TURN_PORT=${TURN_PORT}, TURN_MAX_PORT=${TURN_MAX_PORT}). Use a smaller --port-offset.${NC}"
+        exit 1
+    fi
+}
+
+normalize_instance
+normalize_offset
+derive_instance_env
+
+compose() {
+    local env_prefix=()
+
+    env_prefix+=(TURN_ENV_FILE="$TURN_ENV_FILE")
+    env_prefix+=(SIGNALING_HTTP_HOST_PORT="$SIGNALING_HTTP_HOST_PORT")
+    env_prefix+=(SIGNALING_STREAMER_HOST_PORT="$SIGNALING_STREAMER_HOST_PORT")
+    env_prefix+=(RECORDER_CTRL_HOST_PORT="$RECORDER_CTRL_HOST_PORT")
+    env_prefix+=(ORCHESTRATOR_HEALTH_HOST_PORT="$ORCHESTRATOR_HEALTH_HOST_PORT")
+    env_prefix+=(VTUBER_GAME_TCP_HOST_PORT="$VTUBER_GAME_TCP_HOST_PORT")
+    env_prefix+=(VTUBER_RUNNER_HOST_PORT="$VTUBER_RUNNER_HOST_PORT")
+    env_prefix+=(TURN_PORT="$TURN_PORT")
+    env_prefix+=(TURN_MIN_PORT="$TURN_MIN_PORT")
+    env_prefix+=(TURN_MAX_PORT="$TURN_MAX_PORT")
+
+    if [ -n "$VTUBER_CONTAINER_PREFIX" ]; then
+        env_prefix+=(VTUBER_CONTAINER_PREFIX="$VTUBER_CONTAINER_PREFIX")
+    fi
+    if [ -n "$VTUBER_NETWORK_NAME" ]; then
+        env_prefix+=(VTUBER_NETWORK_NAME="$VTUBER_NETWORK_NAME")
+        env_prefix+=(COMPOSE_PROJECT_NAME="unreal_vtuber_${INSTANCE_ID}")
+    fi
+    if [ -n "$GPU_SELECTION" ]; then
+        env_prefix+=(NVIDIA_VISIBLE_DEVICES="$GPU_SELECTION")
+    fi
+
+    env "${env_prefix[@]}" docker compose -f docker-compose.unreal.yml "$@"
 }
 
 ensure_env() {
@@ -129,15 +266,22 @@ case "$COMMAND" in
 
         echo -e "${GREEN}Starting VTuber with Unreal Engine...${NC}"
 
-        docker network create vtuber_network 2>/dev/null || true
+        docker network create "${VTUBER_NETWORK_NAME:-vtuber_network}" 2>/dev/null || true
 
-        if [ ! -s ".env.turn" ]; then
-            echo -e "${YELLOW}TURN credentials missing; generating .env.turn...${NC}"
-            ./scripts/generate_turn_credentials.sh
+        if [ ! -s "$TURN_ENV_FILE" ]; then
+            echo -e "${YELLOW}TURN credentials missing; generating ${TURN_ENV_FILE}...${NC}"
+            TURN_ENV_FILE="$TURN_ENV_FILE" \
+              TURN_PORT="$TURN_PORT" \
+              TURN_MIN_PORT="$TURN_MIN_PORT" \
+              TURN_MAX_PORT="$TURN_MAX_PORT" \
+              ./scripts/generate_turn_credentials.sh --output "$TURN_ENV_FILE"
         fi
 
         if [ -n "$GPU_SELECTION" ]; then
             echo -e "${YELLOW}Using NVIDIA_VISIBLE_DEVICES=${GPU_SELECTION}${NC}"
+        fi
+        if [ -n "$INSTANCE_ID" ]; then
+            echo -e "${YELLOW}Instance: ${INSTANCE_ID} (project=unreal_vtuber_${INSTANCE_ID}, prefix=${VTUBER_CONTAINER_PREFIX}, ports=+${PORT_OFFSET})${NC}"
         fi
 
         compose up $DETACHED
@@ -148,10 +292,10 @@ case "$COMMAND" in
             check_health
 
             echo -e "\n${GREEN}Access points:${NC}"
-            echo -e "  Signaling health: ${YELLOW}http://localhost:8080/healthz${NC}"
-            echo -e "  Runner health: ${YELLOW}http://localhost:9877/health${NC}"
-            echo -e "  Orchestrator health: ${YELLOW}http://localhost:9090/health${NC}"
-            echo -e "  Unreal TCP (in-container): ${YELLOW}vtuber-unreal-game:7777${NC}"
+            echo -e "  Signaling health: ${YELLOW}http://localhost:${SIGNALING_HTTP_HOST_PORT}/healthz${NC}"
+            echo -e "  Runner health: ${YELLOW}http://localhost:${VTUBER_RUNNER_HOST_PORT}/health${NC}"
+            echo -e "  Orchestrator health: ${YELLOW}http://localhost:${ORCHESTRATOR_HEALTH_HOST_PORT}/health${NC}"
+            echo -e "  Unreal TCP (in-container): ${YELLOW}${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-game:7777${NC}"
             echo -e "  Sample TTS trigger:${YELLOW} $0 test${NC}"
             echo -e "\n${GREEN}View logs with:${NC} $0 logs [service-name]"
         fi
@@ -172,6 +316,9 @@ case "$COMMAND" in
         sleep 2
         if [ -n "$GPU_SELECTION" ]; then
             echo -e "${YELLOW}Using NVIDIA_VISIBLE_DEVICES=${GPU_SELECTION}${NC}"
+        fi
+        if [ -n "$INSTANCE_ID" ]; then
+            echo -e "${YELLOW}Instance: ${INSTANCE_ID} (project=unreal_vtuber_${INSTANCE_ID}, prefix=${VTUBER_CONTAINER_PREFIX}, ports=+${PORT_OFFSET})${NC}"
         fi
         compose up $DETACHED
         ;;
@@ -208,7 +355,7 @@ case "$COMMAND" in
 
     test)
         echo -e "${YELLOW}Sending sample BYOB TTS command...${NC}"
-        docker exec vtuber-unreal-game bash -lc 'printf "TTS_BYOB_/opt/embody/sample-15s.mp3\r\n" | nc -q 1 127.0.0.1 7777' \
+        docker exec "${VTUBER_CONTAINER_PREFIX:-vtuber}-unreal-game" bash -lc 'printf "TTS_BYOB_/opt/embody/sample-15s.mp3\r\n" | nc -q 1 127.0.0.1 7777' \
           && echo -e "${GREEN}Sample command sent. Listen for playback in the stream.${NC}" \
           || echo -e "${RED}Failed to reach Unreal TCP endpoint${NC}"
         ;;


### PR DESCRIPTION
Adds `--instance` (and optional `--port-offset`) to `scripts/start_vtuber_unreal.sh` so multiple Unreal VTuber stacks can run on a single host.

Key behavior:
- Uses an instance-specific external docker network (`vtuber_network_<id>`) to avoid DNS collisions.
- Prefixes container names via `VTUBER_CONTAINER_PREFIX` (default stays `vtuber-*` so single-instance is unchanged).
- Offsets host ports automatically for `--instance 2+` and generates a per-instance TURN env file (`.env.turn.<id>`).

Example:

```bash
./scripts/start_vtuber_unreal.sh start --instance 2 -d
# optional
./scripts/start_vtuber_unreal.sh start --instance 2 --gpu 1 -d
```

Note: This PR is based on #90 (GPU selection) so the diff stays small; once #90 merges, this can be retargeted to `main`.
