### PR TITLE
Matchmaker: streamer_id routing hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Full guide: `docs/orchestrator-onboarding.md`
 Multi-edge deployments:
 - The edge/gateway IP you provide (default `3.150.172.153`) is used for allowlists and TURN DNAT (`TURN_EXTERNAL_IP`).
 - Verify the orchestrator registers on the intended edge matchmaker after onboarding (see `docs/orchestrator-onboarding.md`).
-- If needed, set `SIGNALING_EXTRA_ARGS` in `.env` (example: `--use_matchmaker --matchmaker_address <EDGE_IP> --matchmaker_port 8889`).
+- If needed, set `SIGNALING_EXTRA_ARGS` in `.env` (example: `--use_matchmaker --matchmaker_address <EDGE_IP> --matchmaker_port 8889 --streamer_id <AVATAR_ID>`).
 
 ## What’s inside
 

--- a/docker/embody-app/wilbur-patch/src/MatchmakerClient.ts
+++ b/docker/embody-app/wilbur-patch/src/MatchmakerClient.ts
@@ -8,6 +8,7 @@ export type MatchmakerClientConfig = {
     publicAddress: string;
     publicPort: number;
     publicHttps: boolean;
+    streamerId?: string;
     retryIntervalSeconds: number;
     keepAliveIntervalSeconds: number;
 };
@@ -23,6 +24,7 @@ type MatchmakerMessage =
           address: string;
           port: number;
           https: boolean;
+          streamer_id?: string;
           ready: boolean;
           playerConnected: boolean;
       }
@@ -133,6 +135,7 @@ export class MatchmakerClient {
             address: this.cfg.publicAddress,
             port: this.cfg.publicPort,
             https: this.cfg.publicHttps,
+            streamer_id: this.cfg.streamerId || undefined,
             ready: this.stateProvider.getReady(),
             playerConnected: this.stateProvider.getPlayerConnected()
         };
@@ -166,4 +169,3 @@ export class MatchmakerClient {
         }
     }
 }
-

--- a/docker/embody-app/wilbur-patch/src/index.ts
+++ b/docker/embody-app/wilbur-patch/src/index.ts
@@ -200,6 +200,11 @@ program
         config_file.matchmaker_port || '9999'
     )
     .option(
+        '--streamer_id <id>',
+        'Optional streamer/avatar identifier to send to the Matchmaker for routing.',
+        config_file.streamer_id || ''
+    )
+    .option(
         '--matchmaker_retry_interval <seconds>',
         'Seconds to wait before reconnecting to the Matchmaker after disconnect.',
         config_file.matchmaker_retry_interval || '5'
@@ -400,6 +405,7 @@ if (options.use_matchmaker) {
             publicAddress: publicIp,
             publicPort: publicPort,
             publicHttps: Boolean(options.https),
+            streamerId: String(options.streamer_id || '') || undefined,
             retryIntervalSeconds: parseInt(String(options.matchmaker_retry_interval || '5'), 10),
             keepAliveIntervalSeconds: parseInt(String(options.matchmaker_keep_alive_interval || '30'), 10)
         },

--- a/docs/orchestrator-onboarding.md
+++ b/docs/orchestrator-onboarding.md
@@ -53,7 +53,6 @@ On EC2, security group auto-apply is opt-in: pass `--apply-aws-sg` (requires `aw
 
 ## Verify
 
-- Signaling health: `curl http://127.0.0.1:8080/healthz`
 - Runner health: `curl http://127.0.0.1:9877/health`
 - Orchestrator health: `curl http://127.0.0.1:9090/health`
 
@@ -97,6 +96,8 @@ If your orchestrator is missing:
 - Ensure your signaling server is configured to register with the edge matchmaker:
   - In `.env` set:
     - `SIGNALING_EXTRA_ARGS="--use_matchmaker --matchmaker_address <EDGE_IP> --matchmaker_port 8889"`
+    - Optionally include an avatar routing hint (so the edge can allocate the right orchestrator):
+      - `SIGNALING_EXTRA_ARGS="--use_matchmaker --matchmaker_address <EDGE_IP> --matchmaker_port 8889 --streamer_id <AVATAR_ID>"`
   - Restart: `docker compose -f docker-compose.unreal.yml up -d unreal-signaling`
 - Check signaling logs for matchmaker connectivity:
   - `docker logs vtuber-unreal-signaling --tail 200 | grep -E "Matchmaker|Connected|register" || true`

--- a/scripts/onboard_orchestrator.sh
+++ b/scripts/onboard_orchestrator.sh
@@ -1800,7 +1800,6 @@ fi
 
 note "Health checks (best-effort)"
 curl -fsS --max-time 2 http://127.0.0.1:9877/health >/dev/null 2>&1 || true
-curl -fsS --max-time 2 http://127.0.0.1:8080/healthz >/dev/null 2>&1 || true
 curl -fsS --max-time 2 http://127.0.0.1:9090/health >/dev/null 2>&1 || true
 
 show_reg_help="0"
@@ -1827,7 +1826,6 @@ ${STYLE_MAG}${STYLE_BOLD}NEXT STEPS${STYLE_RESET}
      - ${STYLE_DIM}Edge IPs:${STYLE_RESET} add with ${STYLE_BOLD}--allowed-ip${STYLE_RESET} or ${STYLE_BOLD}--allowed-ips${STYLE_RESET} (or rerun with ${STYLE_BOLD}--advanced${STYLE_RESET}).
 
   ${STYLE_DIM}2) Local health:${STYLE_RESET}
-     - Signaling:    curl http://127.0.0.1:8080/healthz
      - Runner:       curl http://127.0.0.1:9877/health
      - Orchestrator: curl http://127.0.0.1:9090/health
 EOF
@@ -1852,7 +1850,6 @@ Next:
      - Edge IPs: add with --allowed-ip/--allowed-ips (or rerun with --advanced).
 
   2) Verify locally:
-     - Signaling health:    curl http://127.0.0.1:8080/healthz
      - Runner health:       curl http://127.0.0.1:9877/health
      - Orchestrator health: curl http://127.0.0.1:9090/health
 EOF


### PR DESCRIPTION
Adds optional `--streamer_id` that is sent as `streamer_id` in the Matchmaker `connect` message, enabling avatar-specific allocation on the edge/front door.\n\nAlso removes the confusing localhost signaling healthcheck hints from the onboarding wizard/docs (runner + orchestrator health remain).\n\nFollow-up required: deploy the corresponding ps-gateway changes that filter allocation by `streamer_id` and support avatar-bound viewer codes.