### PR TITLE
Fix auto-updater: remove watchtower rolling restart

### DIFF
--- a/docker-compose.unreal.yml
+++ b/docker-compose.unreal.yml
@@ -206,7 +206,6 @@ services:
         "${WATCHTOWER_INTERVAL:-900}",
         "--cleanup",
         "--include-restarting",
-        "--rolling-restart",
         "vtuber-turn-server",
         "vtuber-unreal-signaling",
         "vtuber-script-runner",


### PR DESCRIPTION
Watchtower `--rolling-restart` is incompatible with `vtuber-script-runner` (uses `network_mode: service:unreal-game`), causing repeated update failures.

This change removes `--rolling-restart` so the staging GPU can reliably auto-pull `:latest` images after merges to `main`.
