### PR TITLE
CLI: license redeem + rollout wrapper

### DIFF
--- a/docs/orchestrator-onboarding.md
+++ b/docs/orchestrator-onboarding.md
@@ -124,8 +124,12 @@ on the same edge. See the ops runbook in the `infra-gating` repo for “allocate
 
 To load a new encrypted artifact and restart the stack:
 ```bash
-./tools/encrypted-game-image/rollout.sh \
+./scripts/embody_cli.sh rollout \
   --payments-api-url http://<payments-ip>:8081 \
-  --orch-token-file ~/.embody/orch-license-token.txt \
   --image-ref ghcr.io/its-define/unreal_vtuber/embody-ue-ps:enc-v1
+```
+
+If the license token is missing, redeem your invite code once:
+```bash
+./scripts/embody_cli.sh license redeem
 ```

--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -20,6 +20,8 @@ if [[ "$(id -u)" == "0" && -n "${SUDO_USER:-}" ]]; then
 fi
 
 TOKEN_FILE_DEFAULT="${TARGET_HOME}/.embody/orch-license-token.txt"
+DEFAULT_PAYMENTS_API_URL="http://3.141.111.200:8081"
+DEFAULT_LICENSE_IMAGE_REF="ghcr.io/its-define/unreal_vtuber/embody-ue-ps:enc-v1"
 
 usage() {
   cat <<'EOF'
@@ -28,6 +30,9 @@ Embody Orchestrator CLI
 Usage:
   ./scripts/embody_cli.sh                  # Auto: setup wizard or day-to-day menu
   ./scripts/embody_cli.sh setup [args...]  # Run onboarding wizard
+  ./scripts/embody_cli.sh license          # Show license token status
+  ./scripts/embody_cli.sh license redeem   # Redeem invite code → store token
+  ./scripts/embody_cli.sh rollout          # Rollout encrypted game image (wraps tools/encrypted-game-image/rollout.sh)
 
 Day-to-day commands:
   ./scripts/embody_cli.sh start [--gpu <id|all|none>]   # Start stack (defaults to detached)
@@ -49,6 +54,44 @@ EOF
 
 is_tty() {
   [[ -t 0 && -t 1 ]]
+}
+
+prompt_default() {
+  local label="$1" default="${2:-}" out=""
+  if [[ -n "$default" ]]; then
+    read -r -p "${label} [${default}]: " out || true
+  else
+    read -r -p "${label}: " out || true
+  fi
+  out="$(trim_whitespace "${out:-}")"
+  if [[ -z "$out" ]]; then
+    printf '%s' "$default"
+  else
+    printf '%s' "$out"
+  fi
+}
+
+prompt_secret() {
+  local label="$1" out=""
+  read -r -s -p "${label}: " out || true
+  echo ""
+  out="$(trim_whitespace "${out:-}")"
+  printf '%s' "$out"
+}
+
+prompt_yes_no() {
+  local label="$1" default="${2:-y}" out=""
+  local hint="[y/N]"
+  if [[ "$default" == "y" ]]; then
+    hint="[Y/n]"
+  fi
+  read -r -p "${label} ${hint}: " out || true
+  out="$(trim_whitespace "${out:-}")"
+  out="${out:-$default}"
+  case "$out" in
+    y|Y|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 read_env_value() {
@@ -97,6 +140,13 @@ get_gpu_devices() {
   printf '%s' "$raw"
 }
 
+get_payments_api_url() {
+  local raw
+  raw="$(read_env_value "$ENV_FILE" "PAYMENTS_API_URL" 2>/dev/null || true)"
+  raw="$(strip_inline_comment "$raw")"
+  printf '%s' "$raw"
+}
+
 has_setup_state() {
   [[ -f "$COMPOSE_FILE" ]] || return 1
   [[ -f "$ENV_FILE" ]] || return 1
@@ -133,6 +183,318 @@ run_stack() {
     exit 1
   fi
   exec "$START_SCRIPT" "$@"
+}
+
+is_valid_eth_address() {
+  local addr="$1"
+  [[ "$addr" =~ ^0x[0-9a-fA-F]{40}$ ]]
+}
+
+is_valid_orchestrator_id() {
+  local id="$1"
+  [[ "$id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$ ]]
+}
+
+write_token_file() {
+  local path="$1"
+  local token="$2"
+  local dir
+  dir="$(dirname "$path")"
+
+  umask 077
+  mkdir -p "$dir"
+  chmod 700 "$dir" 2>/dev/null || true
+  printf '%s' "$token" >"$path"
+  chmod 600 "$path" 2>/dev/null || true
+
+  if [[ "$(id -u)" == "0" && -n "${SUDO_USER:-}" ]]; then
+    chown "$SUDO_USER":"$SUDO_USER" "$dir" "$path" 2>/dev/null || true
+  fi
+}
+
+cmd_license() {
+  local sub="${1:-}"
+  shift || true
+
+  case "$sub" in
+    -h|--help|help)
+      cat <<'EOF'
+Usage:
+  ./scripts/embody_cli.sh license
+  ./scripts/embody_cli.sh license redeem [options]
+
+Commands:
+  license           Show token status (path + present/missing)
+  license redeem    Redeem an invite code and store the token locally
+EOF
+      ;;
+    ""|status)
+      local payments_url token_state
+      payments_url="$(get_payments_api_url)"
+      [[ -n "$payments_url" ]] || payments_url="${PAYMENTS_API_URL:-$DEFAULT_PAYMENTS_API_URL}"
+      if [[ -s "$TOKEN_FILE_DEFAULT" ]]; then
+        token_state="present (${TOKEN_FILE_DEFAULT})"
+      else
+        token_state="missing (${TOKEN_FILE_DEFAULT})"
+      fi
+      echo "Payments API:  ${payments_url}"
+      echo "License token: ${token_state}"
+      ;;
+    redeem)
+      local payments_url orch_id orch_addr invite_code invite_code_file invite_code_env token_file
+      local response http_code body payload url token
+
+      payments_url=""
+      orch_id=""
+      orch_addr=""
+      invite_code=""
+      invite_code_file=""
+      invite_code_env=""
+      token_file="$TOKEN_FILE_DEFAULT"
+
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --payments-api-url)
+            payments_url="${2:-}"
+            shift 2
+            ;;
+          --orchestrator-id|--orch-id)
+            orch_id="${2:-}"
+            shift 2
+            ;;
+          --orchestrator-address|--orch-address)
+            orch_addr="${2:-}"
+            shift 2
+            ;;
+          --invite-code)
+            invite_code="${2:-}"
+            shift 2
+            ;;
+          --invite-code-file)
+            invite_code_file="${2:-}"
+            shift 2
+            ;;
+          --invite-code-env)
+            invite_code_env="${2:-}"
+            shift 2
+            ;;
+          --token-file)
+            token_file="${2:-}"
+            shift 2
+            ;;
+          -h|--help)
+            cat <<'EOF'
+Usage:
+  ./scripts/embody_cli.sh license redeem [options]
+
+Options:
+  --payments-api-url <url>         Payments backend base URL (default: PAYMENTS_API_URL from .env)
+  --orchestrator-id <id>           Orchestrator ID (defaults from .env)
+  --orchestrator-address <0x...>   Payout wallet address (defaults from .env)
+  --invite-code <code>             One-time invite code (not recommended; may leak via shell history)
+  --invite-code-file <path>        Read invite code from a file
+  --invite-code-env <ENV>          Read invite code from an env var name
+  --token-file <path>              Where to store the license token (default: ~/.embody/orch-license-token.txt)
+EOF
+            return 0
+            ;;
+          *)
+            echo "Unknown arg for license redeem: $1" >&2
+            return 1
+            ;;
+        esac
+      done
+
+      payments_url="$(trim_whitespace "${payments_url:-}")"
+      orch_id="$(trim_whitespace "${orch_id:-}")"
+      orch_addr="$(trim_whitespace "${orch_addr:-}")"
+      invite_code="$(trim_whitespace "${invite_code:-}")"
+      token_file="$(trim_whitespace "${token_file:-}")"
+
+      if [[ -z "$payments_url" ]]; then
+        payments_url="$(get_payments_api_url)"
+      fi
+      [[ -n "$payments_url" ]] || payments_url="${PAYMENTS_API_URL:-$DEFAULT_PAYMENTS_API_URL}"
+
+      if [[ -z "$orch_id" ]]; then
+        orch_id="$(get_orchestrator_id)"
+      fi
+      if [[ -z "$orch_addr" ]]; then
+        orch_addr="$(get_orchestrator_address)"
+      fi
+
+      if [[ -n "$invite_code_env" ]]; then
+        invite_code="${!invite_code_env:-}"
+        invite_code="$(trim_whitespace "${invite_code:-}")"
+      elif [[ -n "$invite_code_file" ]]; then
+        [[ -f "$invite_code_file" ]] || { echo "Invite code file not found: $invite_code_file" >&2; return 1; }
+        invite_code="$(tr -d '\n' < "$invite_code_file")"
+        invite_code="$(trim_whitespace "${invite_code:-}")"
+      fi
+
+      if is_tty; then
+        if [[ -z "$payments_url" ]]; then
+          payments_url="$(prompt_default "Payments API URL" "$DEFAULT_PAYMENTS_API_URL")"
+        fi
+        if [[ -z "$orch_id" ]]; then
+          orch_id="$(prompt_default "Orchestrator ID" "")"
+        fi
+        if [[ -z "$orch_addr" ]]; then
+          orch_addr="$(prompt_default "Payout wallet (0x...)" "")"
+        fi
+        if [[ -z "$invite_code" ]]; then
+          invite_code="$(prompt_secret "Invite code")"
+        fi
+      fi
+
+      [[ -n "$payments_url" ]] || { echo "Missing payments API URL" >&2; return 1; }
+      [[ -n "$orch_id" ]] || { echo "Missing orchestrator ID (set ORCHESTRATOR_ID in .env or pass --orchestrator-id)" >&2; return 1; }
+      [[ -n "$orch_addr" ]] || { echo "Missing orchestrator address (set ORCHESTRATOR_ADDRESS in .env or pass --orchestrator-address)" >&2; return 1; }
+      [[ -n "$invite_code" ]] || { echo "Missing invite code" >&2; return 1; }
+      [[ -n "$token_file" ]] || { echo "Missing token file path" >&2; return 1; }
+
+      if ! is_valid_orchestrator_id "$orch_id"; then
+        echo "Invalid orchestrator ID: must be 1-64 chars (letters/numbers/dot/underscore/dash), starting with letter/number." >&2
+        return 1
+      fi
+      if ! is_valid_eth_address "$orch_addr"; then
+        echo "Invalid payout wallet: expected 0x + 40 hex chars." >&2
+        return 1
+      fi
+
+      command -v curl >/dev/null 2>&1 || { echo "Missing dependency: curl" >&2; return 1; }
+      command -v python3 >/dev/null 2>&1 || { echo "Missing dependency: python3" >&2; return 1; }
+
+      url="${payments_url%/}/api/licenses/invites/redeem"
+      payload="$(INVITE_CODE="$invite_code" ORCH_ID="$orch_id" ORCH_ADDRESS="$orch_addr" python3 - <<'PY'
+import json
+import os
+
+payload = {
+    "code": os.environ.get("INVITE_CODE", ""),
+    "orchestrator_id": os.environ.get("ORCH_ID", ""),
+    "address": os.environ.get("ORCH_ADDRESS", ""),
+}
+print(json.dumps(payload))
+PY
+      )"
+
+      response="$(curl -sS -X POST -H "Content-Type: application/json" -d "$payload" \
+        -w $'\n%{http_code}' "$url")" || true
+      http_code="${response##*$'\n'}"
+      body="${response%$'\n'*}"
+
+      if [[ "$http_code" != "200" ]]; then
+        case "$http_code" in
+          404) echo "Invite code not found (or already redeemed). Ask your admin for a fresh code." >&2 ;;
+          403) echo "Invite code rejected (wallet mismatch or revoked). Double-check your payout wallet and ask your admin for a new code." >&2 ;;
+          409) echo "Invite code already redeemed (or redemption in progress). If you already redeemed earlier, reuse your token file at ${TOKEN_FILE_DEFAULT}." >&2 ;;
+          410) echo "Invite code expired. Ask your admin for a fresh code." >&2 ;;
+          *) echo "Invite redeem failed (HTTP $http_code)" >&2 ;;
+        esac
+        if [[ -n "$body" ]]; then
+          echo "$body" >&2
+        fi
+        return 1
+      fi
+
+      token="$(BODY="$body" python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("BODY", "") or ""
+try:
+    data = json.loads(raw) if raw else {}
+except Exception:
+    data = {}
+print(data.get("token", "") or "")
+PY
+      )"
+      [[ -n "$token" ]] || { echo "Invite redeem succeeded but token was missing in response" >&2; return 1; }
+
+      write_token_file "$token_file" "$token"
+      echo "Invite redeemed; token stored at ${token_file}"
+      ;;
+    *)
+      echo "Unknown license command: $sub" >&2
+      echo "Run: ./scripts/embody_cli.sh license --help" >&2
+      return 1
+      ;;
+  esac
+}
+
+cmd_rollout() {
+  local payments_url image_ref token_file
+  local passthrough=()
+
+  payments_url=""
+  image_ref="$DEFAULT_LICENSE_IMAGE_REF"
+  token_file="$TOKEN_FILE_DEFAULT"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --payments-api-url)
+        payments_url="${2:-}"
+        shift 2
+        ;;
+      --image-ref)
+        image_ref="${2:-}"
+        shift 2
+        ;;
+      --artifact-url|--compose-file|--game-image)
+        passthrough+=("$1" "${2:-}")
+        shift 2
+        ;;
+      --no-verify|--no-color)
+        passthrough+=("$1")
+        shift 1
+        ;;
+      -h|--help)
+        cat <<'EOF'
+Usage:
+  ./scripts/embody_cli.sh rollout [options]
+
+This wraps `tools/encrypted-game-image/rollout.sh` and uses your stored license token.
+
+Options:
+  --payments-api-url <url>   Payments backend (default: PAYMENTS_API_URL from .env)
+  --image-ref <ref>          Image ref registered in Payments (default: ghcr.io/its-define/unreal_vtuber/embody-ue-ps:enc-v1)
+  --no-verify                Skip health checks after restart
+EOF
+        return 0
+        ;;
+      *)
+        echo "Unknown arg for rollout: $1" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$payments_url" ]]; then
+    payments_url="$(get_payments_api_url)"
+  fi
+  [[ -n "$payments_url" ]] || payments_url="${PAYMENTS_API_URL:-$DEFAULT_PAYMENTS_API_URL}"
+
+  if [[ ! -s "$token_file" ]]; then
+    echo "Missing license token at ${token_file}." >&2
+    if is_tty && prompt_yes_no "Redeem an invite code now?" "y"; then
+      cmd_license redeem --payments-api-url "$payments_url" --token-file "$token_file" || return 1
+    else
+      echo "Run: ./scripts/embody_cli.sh license redeem" >&2
+      return 1
+    fi
+  fi
+
+  if [[ ! -x "$REPO_ROOT/tools/encrypted-game-image/rollout.sh" ]]; then
+    echo "Missing rollout script: $REPO_ROOT/tools/encrypted-game-image/rollout.sh" >&2
+    return 1
+  fi
+
+  "$REPO_ROOT/tools/encrypted-game-image/rollout.sh" \
+    --payments-api-url "$payments_url" \
+    --orch-token-file "$token_file" \
+    --image-ref "$image_ref" \
+    "${passthrough[@]}"
 }
 
 cmd_config() {
@@ -287,6 +649,14 @@ main() {
     setup|onboard)
       shift
       run_setup "$@"
+      ;;
+    license|token)
+      shift || true
+      cmd_license "$@"
+      ;;
+    rollout|update-image)
+      shift || true
+      cmd_rollout "$@"
       ;;
     start|up|stop|down|restart|logs|ps|status|pull|build|test)
       shift

--- a/tools/encrypted-game-image/consume.sh
+++ b/tools/encrypted-game-image/consume.sh
@@ -67,16 +67,6 @@ strip_wrapping_quotes() {
   printf '%s' "$s"
 }
 
-safe_path_component() {
-  local s="$1"
-  s="${s#http://}"
-  s="${s#https://}"
-  s="${s%%/*}"
-  s="${s//:/_}"
-  s="${s//[^a-zA-Z0-9_.-]/_}"
-  printf '%s' "$s"
-}
-
 read_secret_file() {
   local path="$1"
   [[ -f "$path" ]] || return 1
@@ -98,8 +88,12 @@ write_secret_file() {
   dir="$(dirname "$path")"
   umask 077
   mkdir -p "$dir"
+  chmod 700 "$dir" 2>/dev/null || true
   printf '%s\n' "$value" > "$path"
   chmod 600 "$path" 2>/dev/null || true
+  if [[ "$(id -u)" == "0" && -n "${SUDO_USER:-}" ]]; then
+    chown "$SUDO_USER":"$SUDO_USER" "$dir" "$path" 2>/dev/null || true
+  fi
 }
 
 prompt_input() {
@@ -696,8 +690,21 @@ if [[ -n "$invite_code_file" ]]; then
   invite_code="$(normalize_secret "$(read_secret_file "$invite_code_file" 2>/dev/null || true)")"
 fi
 
+# Determine the correct "home" to use for caching when running under sudo.
+target_user="${SUDO_USER:-$USER}"
+target_home=""
+if command -v getent >/dev/null 2>&1; then
+  target_home="$(getent passwd "$target_user" 2>/dev/null | cut -d: -f6 || true)"
+fi
+if [[ -z "$target_home" ]]; then
+  target_home="$(eval echo "~${target_user}" 2>/dev/null || true)"
+fi
+if [[ -z "$target_home" ]]; then
+  target_home="$HOME"
+fi
+
 # Auto-load a cached token if nothing was provided explicitly.
-default_token_file="$HOME/.config/embody/payments/orch-token-$(safe_path_component "$payments_api_url").txt"
+default_token_file="$target_home/.embody/orch-license-token.txt"
 if [[ -z "$orch_token" ]] && [[ -z "$orch_token_file" ]] && [[ -f "$default_token_file" ]]; then
   orch_token="$(normalize_secret "$(read_secret_file "$default_token_file" 2>/dev/null || true)")"
   orch_token_file="$default_token_file"


### PR DESCRIPTION
Follow-up to #101 (now merged). This PR brings in the CLI wrappers and onboarding docs.

What changed
- Adds `./scripts/embody_cli.sh license redeem` and `./scripts/embody_cli.sh rollout`
- Updates `docs/orchestrator-onboarding.md`

How to test
- `./scripts/embody_cli.sh license redeem`
- `./scripts/embody_cli.sh rollout`
