### PR TITLE
CLI: improve onboarding prompts + image load UX

### DIFF
--- a/scripts/embody_onboard.sh
+++ b/scripts/embody_onboard.sh
@@ -1548,8 +1548,15 @@ maybe_run_wizard() {
     fi
   fi
 
+  if [[ -z "$ORCH_ADDRESS" ]]; then
+    if [[ -n "$existing_addr" ]] && is_valid_eth_address "$existing_addr" && ! is_zero_eth_address "$existing_addr"; then
+      ORCH_ADDRESS="$existing_addr"
+      ok "Payout wallet already set in .env (redacted)"
+    fi
+  fi
+
   while [[ -z "$ORCH_ADDRESS" ]]; do
-    ORCH_ADDRESS="$(prompt_default "Orchestrator payout wallet address (0x...)" "${existing_addr:-}")"
+    ORCH_ADDRESS="$(prompt_default "Orchestrator payout wallet address (0x...)" "")"
     if ! is_valid_eth_address "$ORCH_ADDRESS"; then
       note "Wallet address must look like 0x + 40 hex chars"
       ORCH_ADDRESS=""
@@ -1615,13 +1622,17 @@ maybe_run_wizard() {
   EDGE_CONFIG_URL="$(trim_whitespace "$EDGE_CONFIG_URL")"
   EDGE_CONFIG_URL="$(strip_inline_comment "$EDGE_CONFIG_URL")"
   if [[ -n "$EDGE_CONFIG_URL" ]]; then
-    note "Optional: edge config read token (if your control plane requires it)."
-    note "If you already set EDGE_CONFIG_TOKEN in .env, leave blank to keep it."
-    local token_input
-    token_input="$(prompt_secret "Edge config read token (hidden input; optional)")"
-    token_input="$(trim_whitespace "$token_input")"
-    if [[ -n "$token_input" ]]; then
-      EDGE_CONFIG_TOKEN="$token_input"
+    if [[ -n "$EDGE_CONFIG_TOKEN" ]]; then
+      ok "Edge config token already set in .env (redacted)"
+    else
+      note "Optional: edge config read token (if your control plane requires it)."
+      note "If you already set EDGE_CONFIG_TOKEN in .env, leave blank to keep it."
+      local token_input
+      token_input="$(prompt_secret "Edge config read token (hidden input; optional)")"
+      token_input="$(trim_whitespace "$token_input")"
+      if [[ -n "$token_input" ]]; then
+        EDGE_CONFIG_TOKEN="$token_input"
+      fi
     fi
   fi
 
@@ -2107,32 +2118,56 @@ require_cmd jq
 require_cmd zstd
 require_cmd age
 
+detect_game_image_from_compose() {
+  # Extract `services.unreal-game.image` without needing yq.
+  awk '
+    /^[[:space:]]*unreal-game:[[:space:]]*$/ { in_game=1; next }
+    in_game && /^[[:space:]]*image:[[:space:]]*/ {
+      sub(/^[[:space:]]*image:[[:space:]]*/, "", $0)
+      gsub(/[[:space:]]+$/, "", $0)
+      print $0
+      exit
+    }
+    in_game && /^[^[:space:]]/ { in_game=0 }
+  ' "$1"
+}
+
 rollout_args=()
 if [[ "$NO_VERIFY" == "1" ]]; then
   rollout_args+=(--no-verify)
 fi
 
-note "Rolling out encrypted game image + starting compose stack"
-token_args=()
-if [[ -n "$ORCH_TOKEN_ENV" ]]; then
-  token_args+=(--orch-token-env "$ORCH_TOKEN_ENV")
-elif [[ -n "$ORCH_TOKEN_FILE" ]]; then
-  token_args+=(--orch-token-file "$ORCH_TOKEN_FILE")
-elif [[ -n "$ORCH_TOKEN" ]]; then
-  token_args+=(--orch-token "$ORCH_TOKEN")
+game_image="$(detect_game_image_from_compose "$COMPOSE_FILE" || true)"
+game_image="$(trim_whitespace "${game_image:-}")"
+if [[ -n "$game_image" ]] && docker image inspect "$game_image" >/dev/null 2>&1; then
+  ok "Game image already present locally; skipping download"
+  note "To force a clean reload, run: ./scripts/embody_cli.sh rollout"
+  note "Restarting compose stack to apply config"
+  "${compose_cmd[@]}" -f "$COMPOSE_FILE" down
+  "${compose_cmd[@]}" -f "$COMPOSE_FILE" up -d
+else
+  note "Rolling out encrypted game image + starting compose stack"
+  token_args=()
+  if [[ -n "$ORCH_TOKEN_ENV" ]]; then
+    token_args+=(--orch-token-env "$ORCH_TOKEN_ENV")
+  elif [[ -n "$ORCH_TOKEN_FILE" ]]; then
+    token_args+=(--orch-token-file "$ORCH_TOKEN_FILE")
+  elif [[ -n "$ORCH_TOKEN" ]]; then
+    token_args+=(--orch-token "$ORCH_TOKEN")
+  fi
+  rollout_cmd=(
+    "$REPO_ROOT/tools/encrypted-game-image/rollout.sh"
+    --payments-api-url "$PAYMENTS_API_URL"
+    --image-ref "$IMAGE_REF"
+    --orch-id "$ORCH_ID"
+    --orch-address "$ORCH_ADDRESS"
+  )
+  if [[ -n "$ARTIFACT_URL" ]]; then
+    rollout_cmd+=(--artifact-url "$ARTIFACT_URL")
+  fi
+  rollout_cmd+=("${token_args[@]}" "${rollout_args[@]}")
+  "${rollout_cmd[@]}"
 fi
-rollout_cmd=(
-  "$REPO_ROOT/tools/encrypted-game-image/rollout.sh"
-  --payments-api-url "$PAYMENTS_API_URL"
-  --image-ref "$IMAGE_REF"
-  --orch-id "$ORCH_ID"
-  --orch-address "$ORCH_ADDRESS"
-)
-if [[ -n "$ARTIFACT_URL" ]]; then
-  rollout_cmd+=(--artifact-url "$ARTIFACT_URL")
-fi
-rollout_cmd+=("${token_args[@]}" "${rollout_args[@]}")
-"${rollout_cmd[@]}"
 
 ensure_inbound_rules_best_effort
 

--- a/tools/encrypted-game-image/consume.sh
+++ b/tools/encrypted-game-image/consume.sh
@@ -287,6 +287,18 @@ def human_bytes(num: float) -> str:
         value /= 1024.0
     return f"{value:.1f}TB"
 
+def human_duration(seconds: float) -> str:
+    seconds = max(float(seconds), 0.0)
+    s = int(seconds + 0.5)
+    h = s // 3600
+    m = (s % 3600) // 60
+    sec = s % 60
+    if h > 0:
+        return f"{h}h{m:02d}m{sec:02d}s"
+    if m > 0:
+        return f"{m}m{sec:02d}s"
+    return f"{sec}s"
+
 
 label = sys.argv[1] if len(sys.argv) > 1 else "stream"
 use_tty = sys.stderr.isatty()
@@ -299,6 +311,8 @@ CYN = "\033[36m" if use_color else ""
 MAG = "\033[35m" if use_color else ""
 GRN = "\033[32m" if use_color else ""
 YLW = "\033[33m" if use_color else ""
+BOLD = "\033[1m" if use_color else ""
+WHT = "\033[97m" if use_color else ""
 
 bar_len = 24
 pulse_len = 6
@@ -338,8 +352,9 @@ def print_status(now: float, final: bool = False) -> None:
         f"{CYN}[{label}]{RESET} "
         f"{MAG}[{bar_s}]{RESET} "
         f"{GRN}{human_bytes(total)}{RESET} "
-        f"{DIM}@{RESET} {human_bytes(inst_bps)}/s "
-        f"{DIM}(avg {human_bytes(avg_bps)}/s){RESET}"
+        f"{BOLD}{WHT}{human_bytes(inst_bps)}/s{RESET} "
+        f"{DIM}(avg {BOLD}{WHT}{human_bytes(avg_bps)}/s{RESET}{DIM}){RESET} "
+        f"{DIM}elapsed {BOLD}{WHT}{human_duration(elapsed)}{RESET}{DIM}{RESET}"
         f"{idle_s}"
     )
 
@@ -412,6 +427,18 @@ def human_bytes(num: float) -> str:
         value /= 1024.0
     return f"{value:.1f}TB"
 
+def human_duration(seconds: float) -> str:
+    seconds = max(float(seconds), 0.0)
+    s = int(seconds + 0.5)
+    h = s // 3600
+    m = (s % 3600) // 60
+    sec = s % 60
+    if h > 0:
+        return f"{h}h{m:02d}m{sec:02d}s"
+    if m > 0:
+        return f"{m}m{sec:02d}s"
+    return f"{sec}s"
+
 
 label = sys.argv[1] if len(sys.argv) > 1 else "LOAD"
 use_tty = sys.stderr.isatty()
@@ -425,6 +452,8 @@ GRN = "\033[32m" if use_color else ""
 YLW = "\033[33m" if use_color else ""
 CYN = "\033[36m" if use_color else ""
 MAG = "\033[35m" if use_color else ""
+BOLD = "\033[1m" if use_color else ""
+WHT = "\033[97m" if use_color else ""
 
 bar_len = 28
 pulse_len = 7
@@ -468,8 +497,9 @@ def render(now: float, *, final: bool = False) -> None:
         f"{MAG}{label}{RESET} "
         f"{CYN}⟦{bar_s}⟧{RESET} "
         f"{GRN}{human_bytes(total)}{RESET} "
-        f"{DIM}@{RESET} {human_bytes(inst_bps)}/s "
-        f"{DIM}(avg {human_bytes(avg_bps)}/s){RESET}"
+        f"{BOLD}{WHT}{human_bytes(inst_bps)}/s{RESET} "
+        f"{DIM}(avg {BOLD}{WHT}{human_bytes(avg_bps)}/s{RESET}{DIM}){RESET} "
+        f"{DIM}elapsed {BOLD}{WHT}{human_duration(elapsed)}{RESET}{DIM}{RESET}"
         f"{idle_s}"
     )
 


### PR DESCRIPTION
Improves the onboarding UX for re-runs and makes the long image-load progress output easier to read.

- Onboarding: do not show a default payout wallet in the prompt.
  - If `ORCHESTRATOR_ADDRESS` already exists in `.env`, it is reused without printing the address.
- Onboarding: if `EDGE_CONFIG_TOKEN` is already set, skip re-prompting for it.
- Onboarding: if the Unreal game image is already present locally, skip the encrypted download and just restart compose to apply config.
  - For a forced clean reload, users can run `./scripts/embody_cli.sh rollout`.
- Encrypted image consume meter: make speeds more prominent and show elapsed time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves re-run UX and progress visibility in the CLI setup and encrypted image loader.
> 
> - Onboarding (`scripts/embody_onboard.sh`)
>   - Reuse `ORCHESTRATOR_ADDRESS` from `.env` without showing it; prompt has no default value
>   - If `EDGE_CONFIG_TOKEN` already exists, skip re-prompting
>   - Detect existing game image from `docker-compose.unreal.yml` via `detect_game_image_from_compose` and, if present locally, skip encrypted rollout and just restart compose
> - Image load meter (`tools/encrypted-game-image/consume.sh`)
>   - Adds `human_duration` and highlights instantaneous/avg speeds; shows elapsed time in both progress UIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01b3ce57e84d6884b9800f84545ec8a15004a677. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->