### PR TITLE
cli: fix verify false warnings

### DIFF
--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -1663,7 +1663,7 @@ PY
     ui_check "payments ip" "WARN" "(cannot parse IPv4 from PAYMENTS_API_URL; skip allowlist checks)"
   fi
 
-  if curl -fsS --max-time 4 -I https://s3.amazonaws.com/ >/dev/null 2>&1; then
+  if curl -sS --max-time 4 -I https://s3.amazonaws.com/ >/dev/null 2>&1; then
     ui_check "outbound https" "OK" "(s3.amazonaws.com)"
   else
     ui_check "outbound https" "WARN" "(cannot reach s3.amazonaws.com; presigned uploads may fail)"


### PR DESCRIPTION
Fixes two false warnings in `./scripts/embody_cli.sh verify` / `overview`:

1) Outbound HTTPS check: removes `curl -f` so an S3 HEAD 405 doesn’t show as “cannot reach”.
2) TURN DNAT hint: when `EDGE_LOCAL_ALLOWLIST` includes the Payments IP, don’t treat that IP as the “edge allowlisted” IP for TURN expectations.
