### PR TITLE
docs: clarify CLI flow + allowlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You’ll need:
 
 Run:
 ```bash
-git clone https://github.com/its-DeFine/Unreal_Vtuber.git && cd Unreal_Vtuber && ./scripts/embody_cli.sh
+git clone https://github.com/its-DeFine/Unreal_Vtuber.git && cd Unreal_Vtuber && sudo ./scripts/embody_cli.sh
 ```
 
 Day-to-day operations are also done via the CLI (no file edits needed):


### PR DESCRIPTION
Expands the README quickstart with the day-to-day CLI commands and documents which caller IPs are allowlisted by default in plane vs manual mode.