### PR TITLE
Fix edge-rotator bearer token clobbering

### DIFF
--- a/orchestrator-edge-rotator/agent.py
+++ b/orchestrator-edge-rotator/agent.py
@@ -492,7 +492,7 @@ def main() -> int:
         while True:
             time.sleep(60)
 
-    token = (os.environ.get("EDGE_CONFIG_TOKEN") or "").strip()
+    edge_config_token = (os.environ.get("EDGE_CONFIG_TOKEN") or "").strip()
     poll_s = int(os.environ.get("EDGE_POLL_INTERVAL_SECONDS", "15"))
 
     project_dir = (os.environ.get("EDGE_PROJECT_DIR") or "/home/ubuntu/Unreal_Vtuber").strip()
@@ -532,7 +532,7 @@ def main() -> int:
             url = control_plane_url
             q = urllib.parse.urlencode({"orchestrator_id": orch_id})
             url = f"{url}{'&' if '?' in url else '?'}{q}"
-            desired = _http_get_json(url, token=token)
+            desired = _http_get_json(url, token=edge_config_token)
 
             cidrs = _as_cidrs(desired)
             if not cidrs:


### PR DESCRIPTION
Root cause: `orchestrator-edge-rotator` stored the edge-plane bearer token in a local `token` variable, but later reused `token` as a loop variable inside `main()`. In Python, loop vars are function-scoped, so the bearer token was overwritten (often to the selected edge IP), causing requests like `Authorization: Bearer <edge-ip>` and 401s from `/api/orchestrator-edge`.

Fix: rename the bearer token variable to `edge_config_token` so it can’t be clobbered by later loops.

Impact: plane pin/swap becomes reliable again (edge assignment + firewall allowlist updates apply automatically).