### PR TITLE
Cluster mode: multi-instance avatar stacks (deterministic ports)

### DIFF
--- a/docker-compose.unreal.instance.yml
+++ b/docker-compose.unreal.instance.yml
@@ -1,0 +1,147 @@
+
+services:
+  # ===========================================
+  # PER-INSTANCE SERVICES (cluster mode)
+  # ===========================================
+
+  # Signaling Server - WebRTC signaling (UI served from the edge/gateway)
+  unreal-signaling:
+    image: ghcr.io/its-define/unreal_vtuber/embody-signaling:latest
+    container_name: vtuber-${VTUBER_AVATAR_SLUG:?VTUBER_AVATAR_SLUG is required}-unreal-signaling
+    restart: unless-stopped
+    env_file:
+      - .env.turn
+    ports:
+      - "${VTUBER_SIGNALING_PUBLIC_PORT:-8080}:80"
+    environment:
+      PUBLIC_IP: ${PUBLIC_IP:-auto}
+      STUN_SERVER: ${STUN_SERVER:-stun.l.google.com:19302}
+      ENABLE_REST_API: ${ENABLE_REST_API:-0}
+      # Some images/scripts key off these env names.
+      HTTP_PORT: "80"
+      STREAMER_PORT: "8888"
+      SFU_PORT: "8889"
+      SIGNALING_HTTP_PORT: "80"
+      SIGNALING_STREAMER_PORT: "8888"
+      SIGNALING_SFU_PORT: "8889"
+      # Matchmaker args usually come from `.env` (`SIGNALING_MATCHMAKER_ARGS`).
+      # `VTUBER_SIGNALING_INSTANCE_ARGS` is set by `./scripts/embody_cli.sh cluster ...` per instance:
+      #   --public_port <8080+slot> --matchmaker_streamer_id <avatar_id>
+      SIGNALING_EXTRA_ARGS: "${SIGNALING_EXTRA_ARGS:-} ${SIGNALING_MATCHMAKER_ARGS:-} ${VTUBER_SIGNALING_INSTANCE_ARGS:-}"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # Embody Game - Headless Unreal Engine with Pixel Streaming
+  unreal-game:
+    image: ghcr.io/its-define/unreal_vtuber/embody-ue-ps:latest
+    container_name: vtuber-${VTUBER_AVATAR_SLUG:?VTUBER_AVATAR_SLUG is required}-unreal-game
+    restart: unless-stopped
+    runtime: nvidia
+    ulimits:
+      nofile:
+        soft: ${HOST_ULIMIT_NOFILE:-1040}
+        hard: ${HOST_ULIMIT_NOFILE:-1040}
+    ports:
+      - "${VTUBER_GAME_TCP_PORT:-7777}:7777"
+      # Exposes the runner which shares the game network namespace.
+      - "${VTUBER_RUNNER_PORT:-9877}:9877"
+    depends_on:
+      unreal-signaling:
+        condition: service_healthy
+    environment:
+      - PIXEL_STREAMING_URL=ws://unreal-signaling:8888
+      - HOST_ULIMIT_NOFILE=1040
+      - ULIMIT_NOFILE=1040
+      - HOST_LIB_PATHS=/host-libs/usr/lib/x86_64-linux-gnu:/host-libs/lib/x86_64-linux-gnu:/host-libs/lib64:/host-libs/usr/lib64:/host-libs/usr/lib/nvidia
+      - EMBODY_EXTRA_ARGS=-ForceRes -ResX=1920 -ResY=1080 -PixelStreamingAllowCodecNames=H264 -PixelStreamingDisableVP8 -PixelStreamingDisableVP9
+      - NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-all}
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
+    volumes:
+      - /usr/lib/x86_64-linux-gnu:/host-libs/usr/lib/x86_64-linux-gnu:ro
+      - /lib/x86_64-linux-gnu:/host-libs/lib/x86_64-linux-gnu:ro
+      - /lib64:/host-libs/lib64:ro
+      - /usr/lib64:/host-libs/usr/lib64:ro
+      - /usr/lib/nvidia:/host-libs/usr/lib/nvidia:ro
+      - /usr/share/vulkan:/host-libs/usr/share/vulkan:ro
+      - /etc/vulkan:/host-libs/etc/vulkan:ro
+      - /usr/share/glvnd:/host-libs/usr/share/glvnd:ro
+      - ./pixel-streaming/config/ConsoleVariables.ini:/opt/embody/Embody/Saved/Config/LinuxNoEditor/ConsoleVariables.ini:ro
+      - ./pixel-streaming/config/GameUserSettings.ini:/opt/embody/Embody/Saved/Config/LinuxNoEditor/GameUserSettings.ini:ro
+      - ${VTUBER_SESSION_DIR:-/home/ubuntu/vtuber_sessions}:/opt/embody/sessions
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  vtuber-script-runner:
+    image: ghcr.io/its-define/unreal_vtuber/vtuber-script-runner:${EMBODY_SERVICE_IMAGE_TAG:-latest}
+    container_name: vtuber-${VTUBER_AVATAR_SLUG:?VTUBER_AVATAR_SLUG is required}-script-runner
+    network_mode: "service:unreal-game"
+    environment:
+      - VTUBER_SESSION_ROOT=/opt/embody/sessions
+      - VTUBER_TCP_HOST=${VTUBER_TCP_HOST:-127.0.0.1}
+      - VTUBER_TCP_PORT=7777
+      - VTUBER_ALLOWED_ADDRESSES=${VTUBER_ALLOWED_ADDRESSES:-127.0.0.1,::1,172.17.0.1,172.18.0.1}
+    volumes:
+      - ${VTUBER_SESSION_DIR:-/home/ubuntu/vtuber_sessions}:/opt/embody/sessions
+    restart: unless-stopped
+    depends_on:
+      - unreal-game
+
+  vtuber-watchdog:
+    image: ghcr.io/its-define/unreal_vtuber/vtuber-watchdog:${EMBODY_SERVICE_IMAGE_TAG:-latest}
+    container_name: vtuber-${VTUBER_AVATAR_SLUG:?VTUBER_AVATAR_SLUG is required}-watchdog
+    restart: unless-stopped
+    depends_on:
+      - unreal-game
+    environment:
+      - WATCHDOG_COMPOSE_FILE=/workspace/docker-compose.unreal.instance.yml
+      - WATCHDOG_RUNNER_SERVICE=vtuber-script-runner
+      - WATCHDOG_GAME_CONTAINER=vtuber-${VTUBER_AVATAR_SLUG:?VTUBER_AVATAR_SLUG is required}-unreal-game
+      - WATCHDOG_PROJECT_NAME=${VTUBER_INSTANCE_PROJECT_NAME:-}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./docker-compose.unreal.instance.yml:/workspace/docker-compose.unreal.instance.yml:ro
+      - ./.env:/workspace/.env:ro
+      - ./.env.turn:/workspace/.env.turn:ro
+      - /var/lib/vtuber/power-state:/var/lib/vtuber/power-state:ro
+
+  recorder-control:
+    image: ghcr.io/its-define/unreal_vtuber/recorder-control:${EMBODY_SERVICE_IMAGE_TAG:-latest}
+    container_name: vtuber-${VTUBER_AVATAR_SLUG:?VTUBER_AVATAR_SLUG is required}-recorder-control
+    depends_on:
+      - unreal-signaling
+    env_file:
+      - .env.turn
+    environment:
+      - RECORDER_CTRL_PORT=8889
+      - RECORDER_SIGNALING_URL=${RECORDER_SIGNALING_URL:-ws://unreal-signaling:80}
+      - RECORDER_OUTPUT_DIR=/recordings
+      - PY_RECORDER_PATH=/opt/embody/recorder/gs_webrtc_recorder.py
+      - VTUBER_ALLOWED_ADDRESSES=${VTUBER_ALLOWED_ADDRESSES:-127.0.0.1,::1,172.17.0.1,172.18.0.1}
+      # Recorder uses TURN via env (TURN_USER/TURN_PASS/TURN_PORT come from `.env.turn`).
+      - TURN_HOST=${TURN_EXTERNAL_IP:-}
+      - RECORDINGS_API_TOKEN=${RECORDINGS_API_TOKEN:-}
+    volumes:
+      - ${VTUBER_RECORDINGS_DIR:-/recordings}:/recordings
+    command: ["python3", "/opt/embody/recorder/control_server.py"]
+    restart: unless-stopped
+    ports:
+      - "${VTUBER_RECORDER_PORT:-8889}:8889"

--- a/docker/embody-app/wilbur-patch/src/MatchmakerClient.ts
+++ b/docker/embody-app/wilbur-patch/src/MatchmakerClient.ts
@@ -10,6 +10,7 @@ export type MatchmakerClientConfig = {
     publicHttps: boolean;
     retryIntervalSeconds: number;
     keepAliveIntervalSeconds: number;
+    streamerId?: string;
 };
 
 export type MatchmakerStateProvider = {
@@ -25,9 +26,10 @@ type MatchmakerMessage =
           https: boolean;
           ready: boolean;
           playerConnected: boolean;
+          streamer_id?: string;
       }
-    | { type: 'streamerConnected' }
-    | { type: 'streamerDisconnected' }
+    | { type: 'streamerConnected'; streamer_id?: string }
+    | { type: 'streamerDisconnected'; streamer_id?: string }
     | { type: 'clientConnected' }
     | { type: 'clientDisconnected' }
     | { type: 'ping' };
@@ -128,23 +130,27 @@ export class MatchmakerClient {
     }
 
     private sendConnect(): void {
+        const streamerId = (this.cfg.streamerId || '').trim();
         const message: MatchmakerMessage = {
             type: 'connect',
             address: this.cfg.publicAddress,
             port: this.cfg.publicPort,
             https: this.cfg.publicHttps,
             ready: this.stateProvider.getReady(),
-            playerConnected: this.stateProvider.getPlayerConnected()
+            playerConnected: this.stateProvider.getPlayerConnected(),
+            streamer_id: streamerId || undefined
         };
         this.write(message);
     }
 
     sendStreamerConnected(): void {
-        this.write({ type: 'streamerConnected' });
+        const streamerId = (this.cfg.streamerId || '').trim();
+        this.write({ type: 'streamerConnected', streamer_id: streamerId || undefined });
     }
 
     sendStreamerDisconnected(): void {
-        this.write({ type: 'streamerDisconnected' });
+        const streamerId = (this.cfg.streamerId || '').trim();
+        this.write({ type: 'streamerDisconnected', streamer_id: streamerId || undefined });
     }
 
     sendClientConnected(): void {
@@ -166,4 +172,3 @@ export class MatchmakerClient {
         }
     }
 }
-

--- a/docker/embody-app/wilbur-patch/src/index.ts
+++ b/docker/embody-app/wilbur-patch/src/index.ts
@@ -210,6 +210,12 @@ program
         config_file.matchmaker_keep_alive_interval || '30'
     )
     .option(
+        '--matchmaker_streamer_id <id>',
+        'Optional streamer identifier reported to the Matchmaker (used for targeted allocation).',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        ((config_file as any).matchmaker_streamer_id as string) || ''
+    )
+    .option(
         '--auth_token_secret <secret>',
         'If set, requires a HS256 JWT in the player websocket query string (default param "token").',
         config_file.auth_token_secret || ''
@@ -390,7 +396,7 @@ if (options.serve) {
 const signallingServer = new SignallingServer(serverOpts);
 
 if (options.use_matchmaker) {
-    const getReady = () => signallingServer.streamerRegistry.streamers.some((s) => s.streaming);
+    const getReady = () => signallingServer.streamerRegistry.streamers.length > 0;
     const getPlayerConnected = () => signallingServer.playerRegistry.count() > 0;
 
     const matchmaker = new MatchmakerClient(
@@ -401,7 +407,9 @@ if (options.use_matchmaker) {
             publicPort: publicPort,
             publicHttps: Boolean(options.https),
             retryIntervalSeconds: parseInt(String(options.matchmaker_retry_interval || '5'), 10),
-            keepAliveIntervalSeconds: parseInt(String(options.matchmaker_keep_alive_interval || '30'), 10)
+            keepAliveIntervalSeconds: parseInt(String(options.matchmaker_keep_alive_interval || '30'), 10),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            streamerId: String(((options as any).matchmaker_streamer_id as string) || '').trim() || undefined
         },
         { getReady, getPlayerConnected }
     );

--- a/docs/embody-cli.md
+++ b/docs/embody-cli.md
@@ -47,6 +47,18 @@ This repo ships a single entrypoint for onboarding and day-to-day operations: `.
   - `start`, `stop`, `restart`, `status`, `logs [service]`, `health`
 - `update` – fast-forward this repo to `origin/main` (no merges)
 - `upgrade` – `update` plus pull/recreate service containers (safe to run while sleeping; won’t wake the game)
+- `cluster` – multi-instance “cluster mode” (multiple concurrent avatars on one host)
+  - Config: `~/.embody/cluster.json` (override with `EMBODY_CLUSTER_FILE=/path/to/cluster.json`)
+  - Commands: `cluster plan`, `cluster list`, `cluster up`, `cluster down`, `cluster status`, `cluster logs`
+  - Port map (slot-based, deterministic):
+    - Signaling public port: `8080 + slot`
+    - Runner port: `9877 + slot`
+    - Recorder-control port: `8889 + slot`
+  - Per-instance isolation:
+    - Docker compose projects + per-instance networks
+    - Sessions: `${VTUBER_SESSION_DIR}/<avatar>`
+    - Recordings: `${VTUBER_RECORDINGS_DIR}/<avatar>`
+  - Note: `cluster up` enforces a conservative VRAM estimate (8GiB/instance); pass `--force` to bypass.
 
 ## Network / allowlists
 

--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ENV_FILE="${REPO_ROOT}/.env"
 TURN_ENV_FILE="${REPO_ROOT}/.env.turn"
 COMPOSE_FILE="${REPO_ROOT}/docker-compose.unreal.yml"
+INSTANCE_COMPOSE_FILE="${REPO_ROOT}/docker-compose.unreal.instance.yml"
 START_SCRIPT="${REPO_ROOT}/scripts/start_vtuber_unreal.sh"
 ONBOARD_SCRIPT="${REPO_ROOT}/scripts/embody_onboard.sh"
 
@@ -22,8 +23,16 @@ fi
 TOKEN_FILE_DEFAULT="${TARGET_HOME}/.embody/orch-license-token.txt"
 PAYMENTS_VIEWER_TOKEN_FILE_DEFAULT="${TARGET_HOME}/.embody/payments-viewer-token.txt"
 REGISTRATION_STATE_FILE_DEFAULT="${TARGET_HOME}/.embody/orchestrator-registration.json"
+CLUSTER_CONFIG_FILE_DEFAULT="${TARGET_HOME}/.embody/cluster.json"
 DEFAULT_PAYMENTS_API_URL="http://3.141.111.200:8081"
 DEFAULT_LICENSE_IMAGE_REF="ghcr.io/its-define/unreal_vtuber/embody-ue-ps:enc-v1"
+
+CLUSTER_MAX_SLOTS="20"
+CLUSTER_SIGNALING_PORT_BASE="8080"
+CLUSTER_RUNNER_PORT_BASE="9877"
+CLUSTER_RECORDER_PORT_BASE="8889"
+CLUSTER_GAME_TCP_PORT_BASE="7777"
+CLUSTER_HOST_PROJECT_NAME="vtuber-host"
 
 USE_COLOR="0"
 STYLE_RESET=""
@@ -53,6 +62,7 @@ Usage:
   ./scripts/embody_cli.sh register         # Register orchestrator in Payments (cached; skip when already registered)
   ./scripts/embody_cli.sh verify           # Full health/consistency checks (optionally auto-fix)
   ./scripts/embody_cli.sh power            # Sleep/wake via orchestrator-health /power
+  ./scripts/embody_cli.sh cluster <cmd>    # Multi-instance cluster mode (plan/list/up/down/status/logs)
 
 Day-to-day commands:
   ./scripts/embody_cli.sh start [--gpu <id|all|none>]   # Start stack (defaults to detached)
@@ -1319,6 +1329,607 @@ cmd_capacity() {
       echo "  GPU ${idx} (${name}): ${mem}"
     fi
   done
+}
+
+cluster_config_path() {
+  printf '%s' "${EMBODY_CLUSTER_FILE:-$CLUSTER_CONFIG_FILE_DEFAULT}"
+}
+
+cluster_print_example() {
+  cat <<'EOF'
+{
+  "slot_count": 20,
+  "default_gpu": "0",
+  "instances": [
+    { "avatar_id": "ghost", "slot": 0, "gpu": "0" },
+    { "avatar_id": "pon",   "slot": 1, "gpu": "0" }
+  ]
+}
+EOF
+}
+
+cluster_load_config_lines() {
+  local path
+  path="$(cluster_config_path)"
+  [[ -n "$path" ]] || { echo "Missing cluster config path" >&2; return 1; }
+  [[ -f "$path" ]] || { echo "Cluster config not found: $path" >&2; return 1; }
+  command -v python3 >/dev/null 2>&1 || { echo "Missing dependency: python3" >&2; return 1; }
+
+  CLUSTER_PATH="$path" CLUSTER_MAX_SLOTS="$CLUSTER_MAX_SLOTS" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+path = os.environ.get("CLUSTER_PATH") or ""
+max_slots_raw = os.environ.get("CLUSTER_MAX_SLOTS") or "20"
+try:
+    max_slots = int(max_slots_raw)
+except Exception:
+    max_slots = 20
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except FileNotFoundError:
+    print(f"cluster: FAIL (config not found: {path})", file=sys.stderr)
+    raise SystemExit(1)
+except Exception as exc:
+    print(f"cluster: FAIL (invalid JSON in {path}: {exc})", file=sys.stderr)
+    raise SystemExit(1)
+
+if not isinstance(data, dict):
+    print("cluster: FAIL (config must be a JSON object)", file=sys.stderr)
+    raise SystemExit(1)
+
+slot_count = data.get("slot_count") or data.get("slots") or data.get("slotCount") or max_slots
+try:
+    slot_count = int(slot_count)
+except Exception:
+    print("cluster: FAIL (slot_count must be an integer)", file=sys.stderr)
+    raise SystemExit(1)
+if slot_count < 1 or slot_count > max_slots:
+    print(f"cluster: FAIL (slot_count must be 1..{max_slots})", file=sys.stderr)
+    raise SystemExit(1)
+
+instances = data.get("instances") or data.get("avatars") or data.get("vtubers") or []
+if not isinstance(instances, list):
+    print("cluster: FAIL (instances must be a JSON list)", file=sys.stderr)
+    raise SystemExit(1)
+if not instances:
+    print("cluster: FAIL (instances is empty)", file=sys.stderr)
+    raise SystemExit(1)
+
+default_gpu = (data.get("default_gpu") or data.get("defaultGpu") or data.get("gpu") or "all")
+default_gpu = str(default_gpu).strip() or "all"
+
+used_ids: set[str] = set()
+used_slugs: set[str] = set()
+used_slots: set[int] = set()
+next_slot = 0
+
+out: list[tuple[str, str, int, str]] = []
+
+def slugify(raw: str) -> str:
+    s = raw.strip().lower()
+    s = re.sub(r"[^a-z0-9_.-]+", "-", s)
+    s = s.strip("-_.")
+    return s
+
+def alloc_slot() -> int:
+    global next_slot
+    while next_slot in used_slots:
+        next_slot += 1
+    return next_slot
+
+for item in instances:
+    avatar_id = ""
+    slot = None
+    gpu = None
+
+    if isinstance(item, str):
+        avatar_id = item.strip()
+    elif isinstance(item, dict):
+        avatar_id = str(
+            item.get("avatar_id")
+            or item.get("avatar")
+            or item.get("streamer_id")
+            or item.get("streamerId")
+            or item.get("id")
+            or ""
+        ).strip()
+        slot = item.get("slot")
+        gpu = (
+            item.get("gpu")
+            or item.get("gpu_id")
+            or item.get("gpuId")
+            or item.get("nvidia_visible_devices")
+            or item.get("nvidiaVisibleDevices")
+        )
+    else:
+        print("cluster: FAIL (each instance must be an object or string)", file=sys.stderr)
+        raise SystemExit(1)
+
+    if not avatar_id:
+        print("cluster: FAIL (instance missing avatar_id)", file=sys.stderr)
+        raise SystemExit(1)
+    if avatar_id in used_ids:
+        print(f"cluster: FAIL (duplicate avatar_id: {avatar_id})", file=sys.stderr)
+        raise SystemExit(1)
+
+    slug = slugify(avatar_id)
+    if not slug:
+        print(f"cluster: FAIL (avatar_id produces empty slug: {avatar_id})", file=sys.stderr)
+        raise SystemExit(1)
+    if slug in used_slugs:
+        print(f"cluster: FAIL (duplicate avatar slug after normalization: {slug})", file=sys.stderr)
+        raise SystemExit(1)
+
+    if slot is None or (isinstance(slot, str) and not slot.strip()):
+        slot = alloc_slot()
+    try:
+        slot_int = int(slot)
+    except Exception:
+        print(f"cluster: FAIL (slot must be an integer for {avatar_id})", file=sys.stderr)
+        raise SystemExit(1)
+
+    if slot_int < 0 or slot_int >= slot_count:
+        print(f"cluster: FAIL (slot out of range for {avatar_id}: {slot_int} (slot_count={slot_count}))", file=sys.stderr)
+        raise SystemExit(1)
+    if slot_int in used_slots:
+        print(f"cluster: FAIL (duplicate slot {slot_int})", file=sys.stderr)
+        raise SystemExit(1)
+
+    gpu_value = str(gpu if gpu is not None else default_gpu).strip() or default_gpu
+
+    used_ids.add(avatar_id)
+    used_slugs.add(slug)
+    used_slots.add(slot_int)
+    out.append((avatar_id, slug, slot_int, gpu_value))
+
+out.sort(key=lambda t: t[2])
+
+print(f"SLOT_COUNT\t{slot_count}")
+for avatar_id, slug, slot_int, gpu_value in out:
+    print(f"INSTANCE\t{avatar_id}\t{slug}\t{slot_int}\t{gpu_value}")
+PY
+}
+
+get_vtuber_session_dir_base() {
+  local raw
+  raw="$(read_env_value "$ENV_FILE" "VTUBER_SESSION_DIR" 2>/dev/null || true)"
+  raw="$(strip_inline_comment "$raw")"
+  raw="$(trim_whitespace "$raw")"
+  [[ -n "$raw" ]] || raw="/home/ubuntu/vtuber_sessions"
+  printf '%s' "$raw"
+}
+
+get_vtuber_recordings_dir_base() {
+  local raw
+  raw="$(read_env_value "$ENV_FILE" "VTUBER_RECORDINGS_DIR" 2>/dev/null || true)"
+  raw="$(strip_inline_comment "$raw")"
+  raw="$(trim_whitespace "$raw")"
+  [[ -n "$raw" ]] || raw="/home/ubuntu/recordings"
+  printf '%s' "$raw"
+}
+
+ensure_turn_env() {
+  if [[ ! -s "$TURN_ENV_FILE" ]]; then
+    echo "TURN credentials missing; generating .env.turn..." >&2
+    "${REPO_ROOT}/scripts/generate_turn_credentials.sh"
+  fi
+}
+
+cluster_read_config() {
+  CLUSTER_SLOT_COUNT=""
+  CLUSTER_AVATAR_IDS=()
+  CLUSTER_AVATAR_SLUGS=()
+  CLUSTER_SLOTS=()
+  CLUSTER_GPUS=()
+
+  local kind a b c d
+  while IFS=$'\t' read -r kind a b c d; do
+    case "$kind" in
+      SLOT_COUNT)
+        CLUSTER_SLOT_COUNT="$a"
+        ;;
+      INSTANCE)
+        CLUSTER_AVATAR_IDS+=("$a")
+        CLUSTER_AVATAR_SLUGS+=("$b")
+        CLUSTER_SLOTS+=("$c")
+        CLUSTER_GPUS+=("$d")
+        ;;
+    esac
+  done < <(cluster_load_config_lines)
+
+  [[ -n "${CLUSTER_SLOT_COUNT:-}" ]] || CLUSTER_SLOT_COUNT="$CLUSTER_MAX_SLOTS"
+  if [[ "${#CLUSTER_AVATAR_IDS[@]}" -lt 1 ]]; then
+    echo "cluster: no instances configured" >&2
+    return 1
+  fi
+}
+
+cluster_instance_ports() {
+  local slot="$1"
+  local signaling runner recorder game
+  signaling=$(( CLUSTER_SIGNALING_PORT_BASE + slot ))
+  runner=$(( CLUSTER_RUNNER_PORT_BASE + slot ))
+  recorder=$(( CLUSTER_RECORDER_PORT_BASE + slot ))
+  game=$(( CLUSTER_GAME_TCP_PORT_BASE + slot ))
+  printf '%s\t%s\t%s\t%s\n' "$signaling" "$runner" "$recorder" "$game"
+}
+
+cluster_find_instance_index() {
+  local query="$1"
+  local i
+  for i in "${!CLUSTER_AVATAR_IDS[@]}"; do
+    if [[ "${CLUSTER_AVATAR_IDS[$i]}" == "$query" || "${CLUSTER_AVATAR_SLUGS[$i]}" == "$query" ]]; then
+      printf '%s' "$i"
+      return 0
+    fi
+  done
+  return 1
+}
+
+cluster_ensure_docker() {
+  command -v docker >/dev/null 2>&1 || { echo "Missing dependency: docker" >&2; return 1; }
+  docker compose version >/dev/null 2>&1 || { echo "docker compose plugin not available (docker compose)" >&2; return 1; }
+  return 0
+}
+
+cluster_max_slot() {
+  local max="-1" slot
+  for slot in "${CLUSTER_SLOTS[@]}"; do
+    if [[ "$slot" =~ ^[0-9]+$ && "$slot" -gt "$max" ]]; then
+      max="$slot"
+    fi
+  done
+  printf '%s' "$max"
+}
+
+cluster_edge_allow_ports() {
+  local max_slot="$1"
+  local sig_end run_end rec_end
+  sig_end=$(( CLUSTER_SIGNALING_PORT_BASE + max_slot ))
+  run_end=$(( CLUSTER_RUNNER_PORT_BASE + max_slot ))
+  rec_end=$(( CLUSTER_RECORDER_PORT_BASE + max_slot ))
+  printf '%s' "80/tcp,${CLUSTER_SIGNALING_PORT_BASE}-${sig_end}/tcp,${CLUSTER_RUNNER_PORT_BASE}-${run_end}/tcp,${CLUSTER_RECORDER_PORT_BASE}-${rec_end}/tcp,9090/tcp,3478/tcp,3478/udp,49160-49200/udp"
+}
+
+cluster_monitored_services() {
+  local out="vtuber-turn-server"
+  local slug
+  for slug in "${CLUSTER_AVATAR_SLUGS[@]}"; do
+    out+=",vtuber-${slug}-unreal-game,vtuber-${slug}-unreal-signaling"
+  done
+  printf '%s' "$out"
+}
+
+cluster_enforce_capacity() {
+  command -v nvidia-smi >/dev/null 2>&1 || return 0
+
+  local raw
+  raw="$(nvidia-smi --query-gpu=index,memory.total --format=csv,noheader,nounits 2>/dev/null || true)"
+  [[ -n "$raw" ]] || return 0
+
+  declare -A cap
+  local idx mem
+  while IFS=',' read -r idx mem; do
+    idx="$(trim_whitespace "$idx")"
+    mem="$(trim_whitespace "$mem")"
+    if [[ "$idx" =~ ^[0-9]+$ && "$mem" =~ ^[0-9]+$ ]]; then
+      cap["$idx"]=$(( mem / 8192 ))
+    fi
+  done <<<"$raw"
+
+  declare -A need
+  local i gpu
+  for i in "${!CLUSTER_GPUS[@]}"; do
+    gpu="$(trim_whitespace "${CLUSTER_GPUS[$i]}")"
+    [[ -n "$gpu" ]] || gpu="all"
+    if [[ "$gpu" =~ ^[0-9]+$ ]]; then
+      need["$gpu"]=$(( ${need["$gpu"]:-0} + 1 ))
+    fi
+  done
+
+  local violated="0"
+  for idx in "${!need[@]}"; do
+    local want="${need[$idx]}"
+    local have="${cap[$idx]:-0}"
+    if [[ "$have" -gt 0 && "$want" -gt "$have" ]]; then
+      echo "cluster: capacity exceeded on GPU ${idx}: want=${want} estimated=${have} (8GiB/instance)" >&2
+      violated="1"
+    fi
+  done
+
+  [[ "$violated" == "0" ]]
+}
+
+cluster_plan() {
+  cluster_read_config || return 1
+  local cfg
+  cfg="$(cluster_config_path)"
+  echo "Cluster config: $cfg"
+  echo "Instance compose: ${INSTANCE_COMPOSE_FILE}"
+  echo ""
+
+  local max_slot
+  max_slot="$(cluster_max_slot)"
+  if [[ ! "$max_slot" =~ ^[0-9]+$ || "$max_slot" -lt 0 ]]; then
+    echo "cluster: invalid slot set" >&2
+    return 1
+  fi
+
+  local session_base recordings_base
+  session_base="$(get_vtuber_session_dir_base)"
+  recordings_base="$(get_vtuber_recordings_dir_base)"
+
+  local i avatar slug slot gpu ports signaling runner recorder game project
+  echo "Instances:"
+  for i in "${!CLUSTER_AVATAR_IDS[@]}"; do
+    avatar="${CLUSTER_AVATAR_IDS[$i]}"
+    slug="${CLUSTER_AVATAR_SLUGS[$i]}"
+    slot="${CLUSTER_SLOTS[$i]}"
+    gpu="${CLUSTER_GPUS[$i]}"
+    IFS=$'\t' read -r signaling runner recorder game < <(cluster_instance_ports "$slot")
+    project="vtuber-${slug}"
+    echo "  - avatar=${avatar} (slot=${slot}, gpu=${gpu}, project=${project})"
+    echo "    signaling=${signaling} runner=${runner} recorder=${recorder} game_tcp=${game}"
+    echo "    sessions=${session_base%/}/${slug}"
+    echo "    recordings=${recordings_base%/}/${slug}"
+  done
+
+  echo ""
+  echo "Host-level:"
+  echo "  EDGE_ALLOW_PORTS=$(cluster_edge_allow_ports "$max_slot")"
+  echo "  MONITORED_SERVICES=$(cluster_monitored_services)"
+}
+
+cluster_list() {
+  cluster_read_config || return 1
+  local i avatar slug slot gpu
+  for i in "${!CLUSTER_AVATAR_IDS[@]}"; do
+    avatar="${CLUSTER_AVATAR_IDS[$i]}"
+    slug="${CLUSTER_AVATAR_SLUGS[$i]}"
+    slot="${CLUSTER_SLOTS[$i]}"
+    gpu="${CLUSTER_GPUS[$i]}"
+    local game_container="vtuber-${slug}-unreal-game"
+    local status
+    status="$(docker inspect -f '{{.State.Status}}' "$game_container" 2>/dev/null || true)"
+    [[ -n "$status" ]] || status="missing"
+    echo "${avatar}\t${slug}\tslot=${slot}\tgpu=${gpu}\tgame=${status}"
+  done
+}
+
+cluster_up() {
+  cd "$REPO_ROOT"
+  [[ -f "$ENV_FILE" ]] || { echo "Missing .env (run: ./scripts/embody_cli.sh setup)" >&2; return 1; }
+  [[ -f "$COMPOSE_FILE" ]] || { echo "Missing compose file: $COMPOSE_FILE" >&2; return 1; }
+  [[ -f "$INSTANCE_COMPOSE_FILE" ]] || { echo "Missing instance compose file: $INSTANCE_COMPOSE_FILE" >&2; return 1; }
+  cluster_ensure_docker || return 1
+  ensure_turn_env || return 1
+
+  cluster_read_config || return 1
+
+  local force="0"
+  local only=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force)
+        force="1"
+        shift 1
+        ;;
+      *)
+        only+=("$1")
+        shift 1
+        ;;
+    esac
+  done
+
+  if [[ "$force" != "1" ]] && ! cluster_enforce_capacity; then
+    echo "cluster: refusing to start (capacity exceeded). Reconfigure instances/GPU assignment." >&2
+    echo "cluster: re-run with --force to bypass the estimate." >&2
+    return 1
+  fi
+
+  local max_slot
+  max_slot="$(cluster_max_slot)"
+  [[ "$max_slot" =~ ^[0-9]+$ ]] || { echo "cluster: invalid max slot" >&2; return 1; }
+
+  local session_base recordings_base
+  session_base="$(get_vtuber_session_dir_base)"
+  recordings_base="$(get_vtuber_recordings_dir_base)"
+
+  mkdir -p "$session_base" "$recordings_base" || true
+
+  docker network create vtuber_network 2>/dev/null || true
+
+  local edge_ports monitored
+  edge_ports="$(cluster_edge_allow_ports "$max_slot")"
+  monitored="$(cluster_monitored_services)"
+
+  EDGE_ALLOW_PORTS="$edge_ports" MONITORED_SERVICES="$monitored" docker compose \
+    -p "$CLUSTER_HOST_PROJECT_NAME" -f "$COMPOSE_FILE" \
+    up -d --no-deps \
+    turn-server orchestrator-health orchestrator-edge-rotator vtuber-auto-updater orchestrator-registration
+
+  local i avatar slug slot gpu project signaling runner recorder game instance_args session_dir recordings_dir
+  for i in "${!CLUSTER_AVATAR_IDS[@]}"; do
+    avatar="${CLUSTER_AVATAR_IDS[$i]}"
+    slug="${CLUSTER_AVATAR_SLUGS[$i]}"
+    slot="${CLUSTER_SLOTS[$i]}"
+    gpu="$(trim_whitespace "${CLUSTER_GPUS[$i]}")"
+    project="vtuber-${slug}"
+
+    if [[ "${#only[@]}" -gt 0 ]]; then
+      local match="0" q
+      for q in "${only[@]}"; do
+        if [[ "$q" == "$avatar" || "$q" == "$slug" ]]; then
+          match="1"
+          break
+        fi
+      done
+      [[ "$match" == "1" ]] || continue
+    fi
+
+    IFS=$'\t' read -r signaling runner recorder game < <(cluster_instance_ports "$slot")
+    session_dir="${session_base%/}/${slug}"
+    recordings_dir="${recordings_base%/}/${slug}"
+    mkdir -p "$session_dir" "$recordings_dir" || true
+
+    instance_args="--public_port ${signaling} --matchmaker_streamer_id ${avatar}"
+
+    VTUBER_AVATAR_ID="$avatar" \
+      VTUBER_AVATAR_SLUG="$slug" \
+      VTUBER_INSTANCE_PROJECT_NAME="$project" \
+      VTUBER_SIGNALING_PUBLIC_PORT="$signaling" \
+      VTUBER_RUNNER_PORT="$runner" \
+      VTUBER_RECORDER_PORT="$recorder" \
+      VTUBER_GAME_TCP_PORT="$game" \
+      VTUBER_SESSION_DIR="$session_dir" \
+      VTUBER_RECORDINGS_DIR="$recordings_dir" \
+      VTUBER_SIGNALING_INSTANCE_ARGS="$instance_args" \
+      NVIDIA_VISIBLE_DEVICES="${gpu:-all}" \
+      docker compose -p "$project" -f "$INSTANCE_COMPOSE_FILE" up -d
+  done
+}
+
+cluster_down() {
+  cd "$REPO_ROOT"
+  cluster_read_config || return 1
+  cluster_ensure_docker || return 1
+
+  local only=()
+  if [[ $# -gt 0 ]]; then
+    only=("$@")
+  fi
+
+  local i avatar slug project match q
+  for i in "${!CLUSTER_AVATAR_IDS[@]}"; do
+    avatar="${CLUSTER_AVATAR_IDS[$i]}"
+    slug="${CLUSTER_AVATAR_SLUGS[$i]}"
+    project="vtuber-${slug}"
+
+    if [[ "${#only[@]}" -gt 0 ]]; then
+      match="0"
+      for q in "${only[@]}"; do
+        if [[ "$q" == "$avatar" || "$q" == "$slug" ]]; then
+          match="1"
+          break
+        fi
+      done
+      [[ "$match" == "1" ]] || continue
+    fi
+
+    docker compose -p "$project" -f "$INSTANCE_COMPOSE_FILE" down
+  done
+
+  if [[ "${#only[@]}" -eq 0 ]]; then
+    docker compose -p "$CLUSTER_HOST_PROJECT_NAME" -f "$COMPOSE_FILE" down || true
+  fi
+}
+
+cluster_status() {
+  cd "$REPO_ROOT"
+  cluster_read_config || return 1
+  cluster_ensure_docker || return 1
+
+  echo "Host:"
+  docker compose -p "$CLUSTER_HOST_PROJECT_NAME" -f "$COMPOSE_FILE" ps || true
+  echo ""
+
+  local only=()
+  if [[ $# -gt 0 ]]; then
+    only=("$@")
+  fi
+
+  local i avatar slug project match q
+  for i in "${!CLUSTER_AVATAR_IDS[@]}"; do
+    avatar="${CLUSTER_AVATAR_IDS[$i]}"
+    slug="${CLUSTER_AVATAR_SLUGS[$i]}"
+    project="vtuber-${slug}"
+
+    if [[ "${#only[@]}" -gt 0 ]]; then
+      match="0"
+      for q in "${only[@]}"; do
+        if [[ "$q" == "$avatar" || "$q" == "$slug" ]]; then
+          match="1"
+          break
+        fi
+      done
+      [[ "$match" == "1" ]] || continue
+    fi
+
+    echo "Instance: ${avatar} (project=${project})"
+    docker compose -p "$project" -f "$INSTANCE_COMPOSE_FILE" ps || true
+    echo ""
+  done
+}
+
+cluster_logs() {
+  cd "$REPO_ROOT"
+  cluster_read_config || return 1
+  cluster_ensure_docker || return 1
+  local which="${1:-}"
+  local service="${2:-}"
+  [[ -n "$which" ]] || { echo "Usage: ./scripts/embody_cli.sh cluster logs <avatar|slug> [service]" >&2; return 1; }
+  local idx
+  idx="$(cluster_find_instance_index "$which" 2>/dev/null || true)"
+  [[ -n "$idx" ]] || { echo "Unknown instance: $which" >&2; return 1; }
+  local slug="${CLUSTER_AVATAR_SLUGS[$idx]}"
+  local project="vtuber-${slug}"
+  if [[ -n "$service" ]]; then
+    docker compose -p "$project" -f "$INSTANCE_COMPOSE_FILE" logs --tail=200 "$service"
+  else
+    docker compose -p "$project" -f "$INSTANCE_COMPOSE_FILE" logs --tail=200
+  fi
+}
+
+cmd_cluster() {
+  local sub="${1:-}"
+  shift || true
+  case "$sub" in
+    plan)
+      cluster_plan "$@"
+      ;;
+    list)
+      cluster_list "$@"
+      ;;
+    up|start)
+      cluster_up "$@"
+      ;;
+    down|stop)
+      cluster_down "$@"
+      ;;
+    status|ps)
+      cluster_status "$@"
+      ;;
+    logs)
+      cluster_logs "$@"
+      ;;
+    ""|-h|--help|help)
+      cat <<EOF
+Usage:
+  ./scripts/embody_cli.sh cluster plan
+  ./scripts/embody_cli.sh cluster list
+  ./scripts/embody_cli.sh cluster up [--force] [avatar|slug...]
+  ./scripts/embody_cli.sh cluster down [avatar|slug...]
+  ./scripts/embody_cli.sh cluster status [avatar|slug...]
+  ./scripts/embody_cli.sh cluster logs <avatar|slug> [service]
+
+Config:
+  Path: $(cluster_config_path)
+  Override: set EMBODY_CLUSTER_FILE=/path/to/cluster.json
+
+Example:
+$(cluster_print_example)
+EOF
+      ;;
+    *)
+      echo "Unknown cluster command: $sub" >&2
+      return 1
+      ;;
+  esac
 }
 
 cmd_register() {
@@ -2820,6 +3431,10 @@ main() {
       ;;
     config)
       cmd_config
+      ;;
+    cluster)
+      shift || true
+      cmd_cluster "$@"
       ;;
     capacity)
       cmd_capacity


### PR DESCRIPTION
Refs #142

Adds `./scripts/embody_cli.sh cluster ...` to run multiple fully-isolated per-avatar stacks on one host using deterministic port slots (signaling/runner/recorder/game) and per-instance session/recordings dirs.

Also updates the signaling container matchmaker registration to include `streamer_id` via `--matchmaker_streamer_id` so ps-gateway can request a specific avatar instance by id.

Tested on GPU EC2 host `i-065d33d31d9e278e0` (EIP `3.13.33.97`) with two concurrent instances and ps-gateway allocation by avatar id.