### PR TITLE
Issue #150: publish service images with release tags

### DIFF
--- a/.github/workflows/publish-service-images-release-tags.yml
+++ b/.github/workflows/publish-service-images-release-tags.yml
@@ -1,0 +1,77 @@
+name: Publish Service Images (Release Tags)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: vtuber-script-runner
+            image: ghcr.io/its-define/unreal_vtuber/vtuber-script-runner
+            context: ./unreal-script-runner
+            file: ./unreal-script-runner/Dockerfile
+          - name: recorder-control
+            image: ghcr.io/its-define/unreal_vtuber/recorder-control
+            context: ./tools/recorder
+            file: ./tools/recorder/Dockerfile
+          - name: orchestrator-edge-rotator
+            image: ghcr.io/its-define/unreal_vtuber/orchestrator-edge-rotator
+            context: ./orchestrator-edge-rotator
+            file: ./orchestrator-edge-rotator/Dockerfile
+          - name: orchestrator-health
+            image: ghcr.io/its-define/unreal_vtuber/orchestrator-health
+            context: ./orchestrator-health
+            file: ./orchestrator-health/Dockerfile
+          - name: vtuber-watchdog
+            image: ghcr.io/its-define/unreal_vtuber/vtuber-watchdog
+            context: ./docker/watchdog
+            file: ./docker/watchdog/Dockerfile
+          - name: orchestrator-registration
+            image: ghcr.io/its-define/unreal_vtuber/orchestrator-registration
+            context: ./scripts
+            file: ./scripts/Dockerfile.orchestrator-registration
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=ref,event=tag
+            type=sha,format=short,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+


### PR DESCRIPTION
Fixes #150.

Adds a tag-triggered workflow to publish GHCR service images with the git tag name (e.g. `v1.3.1-beta.2`), so orchestrators can pin `EMBODY_SERVICE_IMAGE_TAG` to a release.

- New workflow: `.github/workflows/publish-service-images-release-tags.yml`
- Triggers on `push` tags `v*`.
