### PR TITLE
feat(cli): auto-generate multi-avatar cluster from GPU capacity

### DIFF
--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -284,6 +284,18 @@ get_vram_per_instance_mib() {
   printf '%s' "$raw"
 }
 
+get_auto_gpu_util_max_percent() {
+  local raw="${EMBODY_AUTO_GPU_UTIL_MAX:-20}"
+  raw="$(trim_whitespace "${raw:-}")"
+  if [[ ! "$raw" =~ ^[0-9]+$ ]]; then
+    raw="20"
+  fi
+  if [[ "$raw" -gt 100 ]]; then
+    raw="100"
+  fi
+  printf '%s' "$raw"
+}
+
 extract_host_from_url() {
   local raw="$1"
   URL="$raw" python3 - <<'PY'
@@ -1347,34 +1359,37 @@ cmd_capacity() {
     return 1
   fi
   local raw
-  raw="$(nvidia-smi --query-gpu=index,name,memory.total,memory.used --format=csv,noheader,nounits 2>/dev/null || true)"
+  raw="$(nvidia-smi --query-gpu=index,name,memory.total,memory.used,utilization.gpu --format=csv,noheader,nounits 2>/dev/null || true)"
   if [[ -z "$raw" ]]; then
     echo "nvidia-smi returned no GPU info." >&2
     return 1
   fi
-  local per per_gib devices
+  local per per_gib devices util_max
   per="$(get_vram_per_instance_mib)"
   per_gib=$(( per / 1024 ))
   devices="$(normalize_gpu_devices_csv "$(get_gpu_devices 2>/dev/null || true)")"
+  util_max="$(get_auto_gpu_util_max_percent)"
   if [[ "$devices" == "none" ]]; then
     echo "NVIDIA_VISIBLE_DEVICES=none; no GPUs selected." >&2
     return 1
   fi
-  echo "Estimated capacity (based on FREE VRAM; ~${per_gib}GiB per UE instance):"
+  echo "Estimated capacity (based on FREE VRAM; ~${per_gib}GiB per UE instance; auto uses <=${util_max}% util):"
   local total="0" seen="0"
-  local idx name mem_total mem_used
-  while IFS=',' read -r idx name mem_total mem_used; do
+  local auto_total="0" auto_seen="0"
+  local idx name mem_total mem_used util
+  while IFS=',' read -r idx name mem_total mem_used util; do
     idx="$(trim_whitespace "$idx")"
     name="$(trim_whitespace "$name")"
     mem_total="$(trim_whitespace "$mem_total")"
     mem_used="$(trim_whitespace "${mem_used:-0}")"
+    util="$(trim_whitespace "${util:-0}")"
     [[ -n "$idx" ]] || continue
     if [[ "$devices" != "all" ]]; then
       if [[ "$(csv_has_token "$devices" "$idx")" != "1" ]]; then
         continue
       fi
     fi
-    if [[ "$mem_total" =~ ^[0-9]+$ && "$mem_used" =~ ^[0-9]+$ ]]; then
+    if [[ "$mem_total" =~ ^[0-9]+$ && "$mem_used" =~ ^[0-9]+$ && "$util" =~ ^[0-9]+$ ]]; then
       local free=$(( mem_total - mem_used ))
       if [[ "$free" -lt 0 ]]; then
         free="0"
@@ -1382,10 +1397,17 @@ cmd_capacity() {
       local instances=$(( free / per ))
       total=$(( total + instances ))
       seen=$(( seen + 1 ))
-      echo "  GPU ${idx} (${name}): total=${mem_total} used=${mem_used} free=${free} MiB -> ~${instances} instance(s)"
+      local busy=""
+      if [[ "$util" -gt "$util_max" ]]; then
+        busy=" (busy)"
+      else
+        auto_total=$(( auto_total + instances ))
+        auto_seen=$(( auto_seen + 1 ))
+      fi
+      echo "  GPU ${idx} (${name}): util=${util}%${busy} total=${mem_total} used=${mem_used} free=${free} MiB -> ~${instances} instance(s)"
     else
       seen=$(( seen + 1 ))
-      echo "  GPU ${idx} (${name}): total=${mem_total} used=${mem_used}"
+      echo "  GPU ${idx} (${name}): total=${mem_total} used=${mem_used} util=${util}"
     fi
   done <<<"$raw"
   if [[ "$seen" -eq 0 ]]; then
@@ -1393,6 +1415,7 @@ cmd_capacity() {
     return 1
   fi
   echo "Total: ~${total} instance(s) across ${seen} GPU(s) (NVIDIA_VISIBLE_DEVICES=${devices})"
+  echo "Auto-available: ~${auto_total} instance(s) across ${auto_seen} GPU(s) (util<=${util_max}%)"
 }
 
 cluster_config_path() {
@@ -1414,13 +1437,15 @@ EOF
 
 cluster_nvidia_smi_raw() {
   command -v nvidia-smi >/dev/null 2>&1 || return 1
-  nvidia-smi --query-gpu=index,name,memory.total,memory.used --format=csv,noheader,nounits 2>/dev/null || true
+  nvidia-smi --query-gpu=index,name,memory.total,memory.used,utilization.gpu --format=csv,noheader,nounits 2>/dev/null || true
 }
 
 cluster_auto_estimate_instance_count() {
   local raw="$1" devices="$2" per="$3" max_instances="${4:-}"
   local total="0"
-  local idx mem_total mem_used
+  local idx mem_total mem_used util
+  local util_max
+  util_max="$(get_auto_gpu_util_max_percent)"
 
   devices="$(normalize_gpu_devices_csv "$devices")"
   if [[ "$devices" == "none" ]]; then
@@ -1431,17 +1456,21 @@ cluster_auto_estimate_instance_count() {
     per="8192"
   fi
 
-  while IFS=',' read -r idx _name mem_total mem_used; do
+  while IFS=',' read -r idx _name mem_total mem_used util; do
     idx="$(trim_whitespace "$idx")"
     mem_total="$(trim_whitespace "$mem_total")"
     mem_used="$(trim_whitespace "${mem_used:-0}")"
+    util="$(trim_whitespace "${util:-0}")"
     [[ -n "$idx" ]] || continue
     if [[ "$devices" != "all" ]]; then
       if [[ "$(csv_has_token "$devices" "$idx")" != "1" ]]; then
         continue
       fi
     fi
-    if [[ "$idx" =~ ^[0-9]+$ && "$mem_total" =~ ^[0-9]+$ && "$mem_used" =~ ^[0-9]+$ ]]; then
+    if [[ "$idx" =~ ^[0-9]+$ && "$mem_total" =~ ^[0-9]+$ && "$mem_used" =~ ^[0-9]+$ && "$util" =~ ^[0-9]+$ ]]; then
+      if [[ "$util" -gt "$util_max" ]]; then
+        continue
+      fi
       local free=$(( mem_total - mem_used ))
       if [[ "$free" -lt 0 ]]; then
         free="0"
@@ -1464,7 +1493,9 @@ cluster_auto_estimate_instance_count() {
 cluster_count_available_gpus() {
   local raw="$1" devices="$2" per="$3"
   local count="0"
-  local idx mem_total mem_used
+  local idx mem_total mem_used util
+  local util_max
+  util_max="$(get_auto_gpu_util_max_percent)"
 
   devices="$(normalize_gpu_devices_csv "$devices")"
   if [[ "$devices" == "none" ]]; then
@@ -1475,17 +1506,21 @@ cluster_count_available_gpus() {
     per="8192"
   fi
 
-  while IFS=',' read -r idx _name mem_total mem_used; do
+  while IFS=',' read -r idx _name mem_total mem_used util; do
     idx="$(trim_whitespace "$idx")"
     mem_total="$(trim_whitespace "$mem_total")"
     mem_used="$(trim_whitespace "${mem_used:-0}")"
+    util="$(trim_whitespace "${util:-0}")"
     [[ -n "$idx" ]] || continue
     if [[ "$devices" != "all" ]]; then
       if [[ "$(csv_has_token "$devices" "$idx")" != "1" ]]; then
         continue
       fi
     fi
-    if [[ "$idx" =~ ^[0-9]+$ && "$mem_total" =~ ^[0-9]+$ && "$mem_used" =~ ^[0-9]+$ ]]; then
+    if [[ "$idx" =~ ^[0-9]+$ && "$mem_total" =~ ^[0-9]+$ && "$mem_used" =~ ^[0-9]+$ && "$util" =~ ^[0-9]+$ ]]; then
+      if [[ "$util" -gt "$util_max" ]]; then
+        continue
+      fi
       local free=$(( mem_total - mem_used ))
       if [[ "$free" -ge "$per" ]]; then
         count=$(( count + 1 ))
@@ -1519,6 +1554,8 @@ cluster_write_auto_config() {
   local per per_gib
   per="$(get_vram_per_instance_mib)"
   per_gib=$(( per / 1024 ))
+  local util_max
+  util_max="$(get_auto_gpu_util_max_percent)"
 
   gpu_devices="$(normalize_gpu_devices_csv "$gpu_devices")"
   if [[ "$gpu_devices" == "none" ]]; then
@@ -1553,7 +1590,7 @@ cluster_write_auto_config() {
   chmod 700 "$dir" 2>/dev/null || true
 
   OUT_PATH="$out_path" GPU_RAW="$raw" GPU_DEVICES="$gpu_devices" PREFIX="$avatar_prefix" \
-    MAX_SLOTS="$CLUSTER_MAX_SLOTS" MAX_INSTANCES="$estimate" VRAM_PER_INSTANCE_MIB="$per" python3 - <<'PY'
+    MAX_SLOTS="$CLUSTER_MAX_SLOTS" MAX_INSTANCES="$estimate" VRAM_PER_INSTANCE_MIB="$per" GPU_UTIL_MAX_PERCENT="$(get_auto_gpu_util_max_percent)" python3 - <<'PY'
 import json
 import os
 import re
@@ -1572,6 +1609,7 @@ prefix = slugify(os.environ.get("PREFIX") or "")
 max_slots = int(os.environ.get("MAX_SLOTS") or "20")
 max_instances = int(os.environ.get("MAX_INSTANCES") or "0")
 per_mib = int(os.environ.get("VRAM_PER_INSTANCE_MIB") or "8192")
+util_max = int(os.environ.get("GPU_UTIL_MAX_PERCENT") or "20")
 
 want = max_instances
 if want < 1:
@@ -1590,13 +1628,17 @@ for line in gpu_raw.splitlines():
     idx, name = parts[0], parts[1]
     total = parts[2] if len(parts) >= 3 else ""
     used = parts[3] if len(parts) >= 4 else "0"
+    util = parts[4] if len(parts) >= 5 else "0"
     if allowed is not None and idx not in allowed:
         continue
     try:
         i = int(idx)
         total_m = int(total)
         used_m = int(used)
+        util_p = int(util)
     except Exception:
+        continue
+    if util_p > util_max:
         continue
     free_m = max(0, total_m - used_m)
     cap = max(0, free_m // max(per_mib, 1))
@@ -1642,6 +1684,7 @@ PY
   echo "Tip: ./scripts/embody_cli.sh cluster plan"
   echo "Tip: ./scripts/embody_cli.sh cluster deploy --auto"
   echo "Note: estimate assumes ~${per_gib}GiB VRAM per UE instance (override: EMBODY_VRAM_PER_INSTANCE_MIB=<MiB>)"
+  echo "Note: auto excludes GPUs over ${util_max}% utilization (override: EMBODY_AUTO_GPU_UTIL_MAX=100)"
 }
 
 cluster_load_config_lines() {


### PR DESCRIPTION
Adds GPU autodetection + one-command cluster bringup.

- New: `./scripts/embody_cli.sh cluster init` generates `~/.embody/cluster.json` by inspecting GPUs via `nvidia-smi` (VRAM heuristic, capped to 20 slots).
- New: `--auto` for `cluster up`/`cluster deploy` auto-generates the cluster config when missing (prompted unless `--yes`).
  - Example: `sudo ./scripts/embody_cli.sh cluster deploy --auto --pull missing`
- New: interactive menu entries for `cluster deploy/status/down`.
- Improve: `./scripts/embody_cli.sh capacity` now respects `NVIDIA_VISIBLE_DEVICES` and prints a total estimate.

Notes
- Capacity heuristic defaults to ~8GiB per UE instance; override with `EMBODY_VRAM_PER_INSTANCE_MIB=<MiB>`.
