### PR TITLE
orchestrator-health: per-project sleep/wake for cluster instances

### DIFF
--- a/orchestrator-health/orchestrator_health/remote_health_service.py
+++ b/orchestrator-health/orchestrator_health/remote_health_service.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import logging
 import os
-import threading
 import ipaddress
+import re
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -56,8 +57,14 @@ POWER_SELF_CONTAINER = os.environ.get("POWER_SELF_CONTAINER", "vtuber-orchestrat
 POWER_SELF_SERVICE = os.environ.get("POWER_SELF_SERVICE", "orchestrator-health")
 POWER_RESTART_RUNNER_ON_WAKE = os.environ.get("POWER_RESTART_RUNNER_ON_WAKE", "1") != "0"
 POWER_STOP_RUNNER_ON_SLEEP = os.environ.get("POWER_STOP_RUNNER_ON_SLEEP", "1") != "0"
+POWER_ALLOWED_PROJECT_PREFIXES = _parse_csv("POWER_ALLOWED_PROJECT_PREFIXES", default="vtuber-")
 
 _AUTO_SLEEP_TIMER: threading.Timer | None = None
+_AUTO_SLEEP_TIMERS_BY_PROJECT: dict[str, threading.Timer] = {}
+_PROJECT_AWAKE_UNTIL: dict[str, datetime] = {}
+_PROJECT_LAST_REASON: dict[str, str] = {}
+
+_PROJECT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 
 
 class PowerState(BaseModel):
@@ -65,6 +72,7 @@ class PowerState(BaseModel):
     reason: Optional[str] = None
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     awake_until: Optional[datetime] = None
+    project: Optional[str] = Field(default=None, description="Compose project when power control is scoped.")
 
 
 class PowerRequest(BaseModel):
@@ -167,13 +175,27 @@ def _detect_compose_identity() -> None:
         POWER_SELF_SERVICE = service
 
 
+def _validate_power_project(project: str) -> str:
+    project = project.strip()
+    if not project:
+        raise HTTPException(status_code=400, detail="project is required")
+    if not _PROJECT_NAME_RE.match(project):
+        raise HTTPException(status_code=400, detail="invalid project name")
+    if POWER_ALLOWED_PROJECT_PREFIXES and not any(project.startswith(prefix) for prefix in POWER_ALLOWED_PROJECT_PREFIXES):
+        raise HTTPException(status_code=403, detail="project not allowed")
+    return project
+
+
 def _find_container(
     service_name: str,
     explicit_name: str | None = None,
+    *,
+    project_name: str | None = None,
 ) -> Optional[Any]:
     filters = {"label": [f"com.docker.compose.service={service_name}"]}
-    if POWER_PROJECT_NAME:
-        filters["label"].append(f"com.docker.compose.project={POWER_PROJECT_NAME}")
+    project = project_name or POWER_PROJECT_NAME
+    if project:
+        filters["label"].append(f"com.docker.compose.project={project}")
     containers = docker_client.containers.list(all=True, filters=filters)
     if containers:
         return containers[0]
@@ -185,8 +207,8 @@ def _find_container(
     return None
 
 
-def _stop_container(container_name: str, service_name: str, timeout: int = 10) -> str:
-    container = _find_container(service_name, container_name)
+def _stop_container(container_name: str, service_name: str, timeout: int = 10, *, project_name: str | None = None) -> str:
+    container = _find_container(service_name, container_name, project_name=project_name)
     if container is None:
         return "missing"
     try:
@@ -199,8 +221,8 @@ def _stop_container(container_name: str, service_name: str, timeout: int = 10) -
         raise HTTPException(status_code=500, detail=f"failed to stop {container_name}: {exc}")
 
 
-def _start_container(container_name: str, service_name: str, timeout: int = 10) -> str:
-    container = _find_container(service_name, container_name)
+def _start_container(container_name: str, service_name: str, timeout: int = 10, *, project_name: str | None = None) -> str:
+    container = _find_container(service_name, container_name, project_name=project_name)
     if container is None:
         raise HTTPException(status_code=404, detail=f"{container_name} container not found")
     try:
@@ -220,10 +242,11 @@ def _wait_for_running(
     timeout_seconds: int = 30,
     interval: float = 2.0,
     require_healthy: bool = False,
+    project_name: str | None = None,
 ) -> str:
     deadline = datetime.now(timezone.utc).timestamp() + timeout_seconds
     while datetime.now(timezone.utc).timestamp() < deadline:
-        container = _find_container(service_name, container_name)
+        container = _find_container(service_name, container_name, project_name=project_name)
         if container is None:
             raise HTTPException(status_code=404, detail=f"{container_name} container not found")
         container.reload()
@@ -294,11 +317,12 @@ def _schedule_auto_sleep(seconds: int, reason: str) -> None:
     _AUTO_SLEEP_TIMER = timer
 
 
-def _list_project_containers() -> list[Any]:
+def _list_project_containers(project_name: str | None = None) -> list[Any]:
     _detect_compose_identity()
-    if not POWER_PROJECT_NAME:
+    project = project_name or POWER_PROJECT_NAME
+    if not project:
         return []
-    return docker_client.containers.list(all=True, filters={"label": [f"com.docker.compose.project={POWER_PROJECT_NAME}"]})
+    return docker_client.containers.list(all=True, filters={"label": [f"com.docker.compose.project={project}"]})
 
 
 def _is_self_container(container: Any) -> bool:
@@ -329,10 +353,12 @@ def _should_keep_running(container: Any) -> bool:
     return False
 
 
-def _sleep_all_containers(*, reason: str | None = None) -> dict[str, str]:
+def _sleep_all_containers(*, reason: str | None = None, project_name: str | None = None) -> dict[str, str]:
     """Stop every container in this compose project except this orchestrator-health container."""
-    containers = _list_project_containers()
+    containers = _list_project_containers(project_name)
     if not containers:
+        if project_name:
+            raise HTTPException(status_code=404, detail=f"compose project not found: {project_name}")
         # Fallback: preserve legacy behavior (game + runner) when project discovery fails.
         results: dict[str, str] = {}
         if POWER_STOP_RUNNER_ON_SLEEP:
@@ -375,10 +401,12 @@ def _sleep_all_containers(*, reason: str | None = None) -> dict[str, str]:
     return results
 
 
-def _wake_all_containers(*, timeout_seconds: int = 90) -> dict[str, str]:
+def _wake_all_containers(*, timeout_seconds: int = 90, project_name: str | None = None) -> dict[str, str]:
     """Start the entire stack in dependency order (except orchestrator-health)."""
-    containers = _list_project_containers()
+    containers = _list_project_containers(project_name)
     if not containers:
+        if project_name:
+            raise HTTPException(status_code=404, detail=f"compose project not found: {project_name}")
         # Fallback: legacy behavior (game + runner)
         results: dict[str, str] = {}
         results["game"] = _start_container(POWER_GAME_CONTAINER, POWER_GAME_SERVICE)
@@ -403,7 +431,7 @@ def _wake_all_containers(*, timeout_seconds: int = 90) -> dict[str, str]:
     for service_name, explicit_container, needs_healthy in services:
         if service_name == POWER_SELF_SERVICE:
             continue
-        container = _find_container(service_name, explicit_container)
+        container = _find_container(service_name, explicit_container, project_name=project_name)
         if container is None:
             continue
         if _is_self_container(container):
@@ -419,10 +447,11 @@ def _wake_all_containers(*, timeout_seconds: int = 90) -> dict[str, str]:
                 service_name,
                 timeout_seconds=timeout_seconds,
                 require_healthy=needs_healthy,
+                project_name=project_name,
             )
 
     # Start any remaining stopped containers in this project (best-effort).
-    for container in _list_project_containers():
+    for container in _list_project_containers(project_name):
         if _is_self_container(container):
             continue
         service = (container.labels or {}).get("com.docker.compose.service", "")
@@ -435,6 +464,65 @@ def _wake_all_containers(*, timeout_seconds: int = 90) -> dict[str, str]:
         results[container.name] = container.status
 
     return results
+
+
+def _cancel_project_auto_sleep_timer(project: str) -> None:
+    timer = _AUTO_SLEEP_TIMERS_BY_PROJECT.pop(project, None)
+    if timer is None:
+        return
+    try:
+        timer.cancel()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _auto_sleep_project(*, project: str, reason: str) -> None:
+    try:
+        _PROJECT_AWAKE_UNTIL.pop(project, None)
+        _sleep_all_containers(reason=reason, project_name=project)
+    except Exception:  # pragma: no cover - background thread
+        logger.exception("Project auto-sleep failed (project=%s)", project)
+
+
+def _schedule_project_auto_sleep(seconds: int, *, project: str, reason: str) -> None:
+    _cancel_project_auto_sleep_timer(project)
+    if seconds <= 0:
+        return
+    timer = threading.Timer(seconds, _auto_sleep_project, kwargs={"project": project, "reason": reason})
+    timer.daemon = True
+    timer.start()
+    _AUTO_SLEEP_TIMERS_BY_PROJECT[project] = timer
+
+
+def _power_state_from_project(project: str) -> PowerState:
+    containers = _list_project_containers(project)
+    if not containers:
+        raise HTTPException(status_code=404, detail=f"compose project not found: {project}")
+
+    running = False
+    for container in containers:
+        if _is_self_container(container):
+            continue
+        try:
+            container.reload()
+        except Exception:  # pragma: no cover - defensive
+            pass
+        if getattr(container, "status", "") == "running":
+            running = True
+            break
+
+    awake_until = _PROJECT_AWAKE_UNTIL.get(project)
+    if awake_until and awake_until < datetime.now(timezone.utc):
+        _PROJECT_AWAKE_UNTIL.pop(project, None)
+        awake_until = None
+
+    return PowerState(
+        state="awake" if running else "sleeping",
+        reason=_PROJECT_LAST_REASON.get(project),
+        updated_at=datetime.now(timezone.utc),
+        awake_until=awake_until,
+        project=project,
+    )
 
 
 @app.get("/health")
@@ -450,6 +538,13 @@ def read_health() -> dict:
 def read_power_state() -> PowerState:
     """Return the current power/sleep state."""
     return _read_power_state()
+
+
+@app.get("/power/projects/{project}", response_model=PowerState)
+def read_project_power_state(project: str) -> PowerState:
+    """Return the current power/sleep state for a specific compose project."""
+    project = _validate_power_project(project)
+    return _power_state_from_project(project)
 
 
 @app.post("/power", response_model=PowerState)
@@ -476,6 +571,34 @@ def change_power_state(payload: PowerRequest, request: Request) -> PowerState:
     if payload.awake_seconds:
         _schedule_auto_sleep(payload.awake_seconds, reason="auto-sleep after wake TTL")
     return state
+
+
+@app.post("/power/projects/{project}", response_model=PowerState)
+def change_project_power_state(project: str, payload: PowerRequest, request: Request) -> PowerState:
+    """Sleep/wake a specific compose project (e.g. a cluster instance)."""
+    _require_auth(request)
+    project = _validate_power_project(project)
+
+    if payload.action == "sleep":
+        _cancel_project_auto_sleep_timer(project)
+        _PROJECT_AWAKE_UNTIL.pop(project, None)
+        if payload.reason:
+            _PROJECT_LAST_REASON[project] = payload.reason
+        _sleep_all_containers(reason=payload.reason, project_name=project)
+        return _power_state_from_project(project)
+
+    # wake
+    _cancel_project_auto_sleep_timer(project)
+    awake_until: Optional[datetime] = None
+    if payload.awake_seconds:
+        awake_until = datetime.now(timezone.utc) + timedelta(seconds=payload.awake_seconds)
+    if payload.reason:
+        _PROJECT_LAST_REASON[project] = payload.reason
+    _wake_all_containers(timeout_seconds=120, project_name=project)
+    if awake_until is not None:
+        _PROJECT_AWAKE_UNTIL[project] = awake_until
+        _schedule_project_auto_sleep(payload.awake_seconds or 0, project=project, reason="auto-sleep after wake TTL")
+    return _power_state_from_project(project)
 
 
 def main() -> None:

--- a/orchestrator-health/orchestrator_health/service_monitor.py
+++ b/orchestrator-health/orchestrator_health/service_monitor.py
@@ -24,10 +24,14 @@ class ServiceMonitor:
         remote_health_url: Optional[str] = None,
         remote_health_timeout: float = 5.0,
     ) -> None:
+        docker_api_version = (os.environ.get("DOCKER_API_VERSION") or "").strip()
         try:
-            self.docker_client = docker.from_env()
+            self.docker_client = docker.from_env(version=docker_api_version or None)
         except Exception:  # pragma: no cover - fallback for custom sockets
-            self.docker_client = docker.DockerClient(base_url="unix://var/run/docker.sock")
+            self.docker_client = docker.DockerClient(
+                base_url="unix://var/run/docker.sock",
+                version=docker_api_version or "1.41",
+            )
 
         env_services = os.environ.get("MONITORED_SERVICES")
         if env_services:

--- a/orchestrator-health/tests/test_power_api.py
+++ b/orchestrator-health/tests/test_power_api.py
@@ -10,6 +10,8 @@ def power_app(monkeypatch, tmp_path):
     # Clear env to defaults for predictable tests
     monkeypatch.delenv("POWER_ALLOWED_IPS", raising=False)
     monkeypatch.delenv("VTUBER_ALLOWED_ADDRESSES", raising=False)
+    monkeypatch.delenv("POWER_ALLOWED_PROJECT_PREFIXES", raising=False)
+    monkeypatch.setenv("DOCKER_API_VERSION", "1.41")
     monkeypatch.setenv("POWER_STATE_FILE", str(tmp_path / "power_state.json"))
     import orchestrator_health.remote_health_service as svc
 
@@ -44,9 +46,10 @@ def test_allowed_ips_empty_primary_falls_back_to_vtuber(monkeypatch):
     assert svc.POWER_ALLOWED_IPS == ["1.1.1.1"]
 
 
-def test_power_state_roundtrip(power_app):
+def test_power_state_roundtrip(power_app, monkeypatch):
     app, svc = power_app
     client = TestClient(app)
+    monkeypatch.setattr(svc, "_sleep_all_containers", lambda *args, **kwargs: {})
     # no auth enforcement when allowlist empty
     resp = client.post("/power", json={"action": "sleep", "reason": "pytest"})
     assert resp.status_code == 200
@@ -94,3 +97,69 @@ def test_wake_with_awake_seconds_sets_awake_until(power_app, monkeypatch):
     assert data["state"] == "awake"
     assert data["awake_until"] is not None
     assert scheduled["seconds"] == 10
+
+
+def test_project_power_roundtrip(power_app, monkeypatch):
+    app, svc = power_app
+    client = TestClient(app)
+
+    class DummyContainer:
+        def __init__(self, name: str, status: str, *, labels: dict[str, str]):
+            self.name = name
+            self.status = status
+            self.labels = labels
+            self.attrs = {"State": {}}
+
+        def reload(self) -> None:  # pragma: no cover - used by service code
+            return None
+
+    project = "vtuber-embody-0"
+    containers = [
+        DummyContainer(
+            name="vtuber-embody-0-unreal-game",
+            status="running",
+            labels={"com.docker.compose.project": project, "com.docker.compose.service": "unreal-game"},
+        )
+    ]
+
+    def fake_list(project_name=None):
+        assert project_name == project
+        return containers
+
+    def fake_sleep(*, reason=None, project_name=None):
+        assert project_name == project
+        for c in containers:
+            c.status = "exited"
+        return {}
+
+    def fake_wake(*, timeout_seconds=90, project_name=None):
+        assert project_name == project
+        for c in containers:
+            c.status = "running"
+        return {}
+
+    monkeypatch.setattr(svc, "_list_project_containers", fake_list)
+    monkeypatch.setattr(svc, "_sleep_all_containers", fake_sleep)
+    monkeypatch.setattr(svc, "_wake_all_containers", fake_wake)
+
+    resp = client.get(f"/power/projects/{project}")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "awake"
+    assert resp.json()["project"] == project
+
+    resp = client.post(f"/power/projects/{project}", json={"action": "sleep", "reason": "pytest"})
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "sleeping"
+    assert resp.json()["project"] == project
+
+    resp = client.post(f"/power/projects/{project}", json={"action": "wake", "reason": "pytest"})
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "awake"
+    assert resp.json()["project"] == project
+
+
+def test_project_power_rejects_non_vtuber_projects(power_app):
+    app, _svc = power_app
+    client = TestClient(app)
+    resp = client.get("/power/projects/docker-default")
+    assert resp.status_code == 403

--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -2632,27 +2632,73 @@ cmd_power() {
 Usage:
   ./scripts/embody_cli.sh power
   ./scripts/embody_cli.sh power status
-  ./scripts/embody_cli.sh power sleep
-  ./scripts/embody_cli.sh power wake [--ttl <seconds>]
+  ./scripts/embody_cli.sh power status [--project <compose_project>]
+  ./scripts/embody_cli.sh power sleep [--project <compose_project>]
+  ./scripts/embody_cli.sh power wake [--ttl <seconds>] [--project <compose_project>]
 EOF
       return 0
       ;;
     ""|status)
-      curl -fsS --max-time 2 http://127.0.0.1:9090/power
+      local project=""
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --project)
+            project="${2:-}"
+            shift 2
+            ;;
+          -h|--help)
+            exec "$0" power --help
+            ;;
+          *)
+            echo "Unknown arg for power status: $1" >&2
+            return 1
+            ;;
+        esac
+      done
+      local endpoint="http://127.0.0.1:9090/power"
+      if [[ -n "$project" ]]; then
+        endpoint="http://127.0.0.1:9090/power/projects/${project}"
+      fi
+      curl -fsS --max-time 2 "$endpoint"
       echo ""
       ;;
     sleep)
-      curl -fsS --max-time 5 -X POST http://127.0.0.1:9090/power \
+      local project=""
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --project)
+            project="${2:-}"
+            shift 2
+            ;;
+          -h|--help)
+            exec "$0" power --help
+            ;;
+          *)
+            echo "Unknown arg for power sleep: $1" >&2
+            return 1
+            ;;
+        esac
+      done
+      local endpoint="http://127.0.0.1:9090/power"
+      if [[ -n "$project" ]]; then
+        endpoint="http://127.0.0.1:9090/power/projects/${project}"
+      fi
+      curl -fsS --max-time 5 -X POST "$endpoint" \
         -H "Content-Type: application/json" \
         -d '{"action":"sleep","reason":"cli"}'
       echo ""
       ;;
     wake)
       local ttl=""
+      local project=""
       while [[ $# -gt 0 ]]; do
         case "$1" in
           --ttl)
             ttl="${2:-}"
+            shift 2
+            ;;
+          --project)
+            project="${2:-}"
             shift 2
             ;;
           -h|--help)
@@ -2678,7 +2724,11 @@ print(json.dumps({"action": "wake", "reason": "cli", "awake_seconds": sec}))
 PY
         )" || { echo "Invalid --ttl value (expected integer seconds)" >&2; return 1; }
       fi
-      curl -fsS --max-time 10 -X POST http://127.0.0.1:9090/power \
+      local endpoint="http://127.0.0.1:9090/power"
+      if [[ -n "$project" ]]; then
+        endpoint="http://127.0.0.1:9090/power/projects/${project}"
+      fi
+      curl -fsS --max-time 10 -X POST "$endpoint" \
         -H "Content-Type: application/json" \
         -d "$payload"
       echo ""


### PR DESCRIPTION
Closes #153

Adds per-compose-project power control so a multi-avatar cluster can sleep/wake a single instance without affecting host services.

- New endpoints: `GET/POST /power/projects/{project}` (validated to `vtuber-*` by default)
- Keeps existing `GET/POST /power` behavior for the host stack
- CLI: `./scripts/embody_cli.sh power ... --project vtuber-embody-0`

Test plan:
- `cd orchestrator-health && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt pytest httpx && PYTHONPATH=. pytest`
- On a cluster host: `curl -X POST http://127.0.0.1:9090/power/projects/vtuber-embody-0 -H 'content-type: application/json' -d '{"action":"sleep"}'` then confirm edge `/api/status` drops that port.
