### PR TITLE
docs: onboarding for v1.3.1-beta.4 (cluster + per-avatar power)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ Run:
 git clone https://github.com/its-DeFine/Unreal_Vtuber.git && cd Unreal_Vtuber && sudo ./scripts/embody_cli.sh
 ```
 
+Recommended: pin to a release tag (avoids “main drift” and guarantees service images match the CLI version):
+```bash
+git fetch --tags
+git checkout v1.3.1-beta.4
+sudo ./scripts/embody_cli.sh
+```
+
 Day-to-day operations are also done via the CLI (no file edits needed):
 - `./scripts/embody_cli.sh overview` – status dashboard (power, containers, registration)
 - `./scripts/embody_cli.sh verify --fix` – health + end-to-end checks (runner TCP + record/download)
 - `./scripts/embody_cli.sh power sleep|wake --ttl <seconds>` – stop/start the stack safely
 - `./scripts/embody_cli.sh upgrade` – update repo + pull/recreate service containers (recommended after updates)
 - `./scripts/embody_cli.sh update` – fast-forward this repo to latest `origin/main` (does not recreate containers)
+
+Important: the Unreal game image is delivered **encrypted** (not anonymously pullable from GHCR).
+If you see `denied` pulling `ghcr.io/.../embody-ue-ps:*`, run:
+- `./scripts/embody_cli.sh rollout` (Payments lease → download/decrypt/load)
 
 The wizard will:
 - Preflight your host (and can install missing deps on Ubuntu/Debian)
@@ -45,6 +56,31 @@ Multi-edge deployments:
 - Verify the orchestrator registers on the intended edge matchmaker after onboarding (see `docs/orchestrator-onboarding.md`).
 - If needed, set `SIGNALING_MATCHMAKER_ARGS` in `.env` (example: `--use_matchmaker --matchmaker_address <EDGE_IP> --matchmaker_port 8889`).
 - To rotate edges without SSH (recommended), enable control-plane mode (`EDGE_CONFIG_URL`) so the included `orchestrator-edge-rotator` sidecar can manage edge assignment (`docs/orchestrator-onboarding.md`).
+
+## Cluster mode (multiple avatars on one GPU host)
+
+Cluster mode runs multiple isolated Pixel Streaming stacks on one host (one compose project per avatar) so an edge can allocate multiple concurrent sessions.
+
+One-command deploy (auto-configures based on GPU VRAM, then launches all instances):
+```bash
+sudo ./scripts/embody_cli.sh cluster deploy --auto --yes --pull missing
+```
+
+Cap the number of instances:
+```bash
+sudo ./scripts/embody_cli.sh cluster deploy --auto --yes --max-instances 12 --pull missing
+```
+
+## Per-avatar sleep/wake (cluster mode)
+
+In cluster mode, each avatar is its own compose project (example: `vtuber-embody-0`). You can sleep/wake a single avatar locally:
+```bash
+./scripts/embody_cli.sh power sleep --project vtuber-embody-0
+./scripts/embody_cli.sh power wake --ttl 3600 --project vtuber-embody-0
+```
+
+Remote automation (ex: Payments) can call:
+- `POST http://<host>:9090/power/projects/<compose_project>`
 
 ## Security / allowlists
 

--- a/docs/embody-cli.md
+++ b/docs/embody-cli.md
@@ -41,7 +41,8 @@ This repo ships a single entrypoint for onboarding and day-to-day operations: `.
 - `register` – register orchestrator in Payments (cached; skips when already registered)
 - `license` / `license redeem` – view or redeem license token (invite code → token)
 - `rollout` – load encrypted game image (wrapper for `tools/encrypted-game-image/rollout.sh`)
-- `power` – sleep/wake the stack via `http://127.0.0.1:9090/power`
+- `power` – sleep/wake the stack via `http://127.0.0.1:9090/power` (or a single compose project via `/power/projects/<project>`)
+  - `power sleep|wake --project <compose_project>` targets one cluster instance (example: `vtuber-embody-0`)
   - `power wake --ttl <seconds>` sets an auto-sleep TTL on wake
 - Day-to-day stack control:
   - `start`, `stop`, `restart`, `status`, `logs [service]`, `health`

--- a/docs/sleep-wake.md
+++ b/docs/sleep-wake.md
@@ -11,6 +11,8 @@ skips recovery while sleeping.
   - `{"action":"sleep","reason":"maintenance"}` – stop all orchestrator containers (except `orchestrator-health`).
   - `{"action":"wake"}` – start all containers in dependency order.
   - `{"action":"wake","awake_seconds":3600}` – start all containers, then auto-sleep after `awake_seconds`.
+- `GET /power/projects/{project}` – returns current power state for a specific compose project (cluster instance).
+- `POST /power/projects/{project}` – same body as `POST /power`, but targets only that compose project.
 - `GET /health` – continues to report service status; while sleeping, game shows as exited.
 
 ## Auth / allowlist
@@ -19,12 +21,15 @@ skips recovery while sleeping.
 - `POWER_ALLOWED_IPS_FILE` (optional) points at a host-mounted file containing the same CSV allowlist.
   If present and non-empty, it overrides `POWER_ALLOWED_IPS` (useful when another service rotates edges).
 - Requests from other IPs receive a 403.
+- `POWER_ALLOWED_PROJECT_PREFIXES` restricts which compose projects can be controlled via `/power/projects/*`
+  (defaults to `vtuber-`).
 
 ## Behavior
 - `sleep` writes state first, then stops every container in the compose project except itself (and any service
   listed in `POWER_KEEP_RUNNING_SERVICES`).
 - `wake` flips state to `awake`, starts the stack in dependency order (TURN → signaling → game → runner/recorder/watchdog).
 - If `awake_seconds` is provided on wake, the service schedules an automatic `sleep` after that TTL (best-effort).
+- For cluster mode, `/power/projects/{project}` sleeps/wakes only that instance’s compose project (example: `vtuber-embody-0`).
 
 ## Compose wiring
 `docker-compose.unreal.yml` already mounts the shared power-state file and passes the
@@ -62,4 +67,14 @@ curl -X POST -H "Content-Type: application/json" \
 curl -X POST -H "Content-Type: application/json" \
   -d '{"action":"wake","awake_seconds":3600,"reason":"session TTL"}' \
   http://<host>:9090/power
+
+# sleep a single cluster instance project
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"action":"sleep","reason":"maintenance"}' \
+  http://<host>:9090/power/projects/vtuber-embody-0
+
+# wake a single cluster instance project for 1 hour
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"action":"wake","awake_seconds":3600,"reason":"session TTL"}' \
+  http://<host>:9090/power/projects/vtuber-embody-0
 ```


### PR DESCRIPTION
Updates README and CLI docs with:\n- Pin-to-tag example (v1.3.1-beta.4)\n- Cluster deploy one-liner + max-instances\n- Per-avatar sleep/wake via /power/projects/{project} + CLI --project\n- Reminder to use `rollout` for the encrypted game image (avoid GHCR denied)