### PR TITLE
docs: cluster deploy uses --no-update when pinned

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Cluster mode runs multiple isolated Pixel Streaming stacks on one host (one comp
 
 One-command deploy (auto-configures based on GPU VRAM, then launches all instances):
 ```bash
-sudo ./scripts/embody_cli.sh cluster deploy --auto --yes --pull missing
+sudo ./scripts/embody_cli.sh cluster deploy --no-update --auto --yes --pull missing
 ```
 
 Cap the number of instances:
 ```bash
-sudo ./scripts/embody_cli.sh cluster deploy --auto --yes --max-instances 12 --pull missing
+sudo ./scripts/embody_cli.sh cluster deploy --no-update --auto --yes --max-instances 12 --pull missing
 ```
 
 ## Per-avatar sleep/wake (cluster mode)

--- a/docs/embody-cli.md
+++ b/docs/embody-cli.md
@@ -52,6 +52,7 @@ This repo ships a single entrypoint for onboarding and day-to-day operations: `.
   - Config: `~/.embody/cluster.json` (override with `EMBODY_CLUSTER_FILE=/path/to/cluster.json`)
   - Commands: `cluster plan`, `cluster list`, `cluster up`, `cluster deploy`, `cluster down`, `cluster status`, `cluster logs`
     - `cluster deploy` is a convenience wrapper: `update` + `pull` + `cluster up --recreate` (disable pieces with `--no-update`, `--no-pull`, `--no-recreate`)
+    - If you’re pinned to a release tag, use `cluster deploy --no-update ...` to avoid switching to `main`
   - Port map (slot-based, deterministic):
     - Signaling public port: `8080 + slot`
     - Runner port: `9877 + slot`


### PR DESCRIPTION
Small UX fix: README and CLI docs now show `cluster deploy --no-update` so hosts pinned to a release tag don’t get prompted/switched to `main`.