### PR TITLE
consume.sh: fix base64 decode detection

### DIFF
--- a/tools/encrypted-game-image/consume.sh
+++ b/tools/encrypted-game-image/consume.sh
@@ -934,10 +934,10 @@ identity_file="$(mktemp)"
 chmod 600 "$identity_file"
 
 # secret_b64 is expected to be base64(identity-file-bytes)
-if command -v base64 >/dev/null 2>&1 && base64 --help 2>&1 | grep -q -- ' -d'; then
-  printf '%s' "$secret_b64" | base64 -d >"$identity_file"
-elif command -v base64 >/dev/null 2>&1 && base64 --help 2>&1 | grep -q -- ' -D'; then
-  printf '%s' "$secret_b64" | base64 -D >"$identity_file"
+if command -v base64 >/dev/null 2>&1; then
+  if ! printf '%s' "$secret_b64" | base64 -d >"$identity_file" 2>/dev/null; then
+    printf '%s' "$secret_b64" | base64 -D >"$identity_file" 2>/dev/null || die "base64 decode not available"
+  fi
 else
   die "base64 decode not available"
 fi


### PR DESCRIPTION
Fixes a BusyBox/Alpine incompatibility in tools/encrypted-game-image/consume.sh.

BusyBox base64 supports -d, but its --help output doesn’t include the exact ' -d' substring we were grepping for, so consume.sh would fail with: "base64 decode not available".

This change simply tries base64 -d and falls back to -D if needed, which keeps Linux + macOS behavior working and unblocks /ops/rollout on Alpine-based executor containers.