### PR TITLE
Docs: clarify port publishing vs SG vs iptables

### DIFF
--- a/docs/embody-cli.md
+++ b/docs/embody-cli.md
@@ -86,6 +86,9 @@ q) Quit
     - Signaling public port: `8080 + slot`
     - Runner port: `9877 + slot`
     - Recorder-control port: `8889 + slot`
+  - Networking note:
+    - Docker/Compose publishes the ports; your cloud firewall / Security Group decides whether they are reachable.
+    - If you use `orchestrator-edge-rotator`, it restricts access via host `iptables` allowlists, but it does not modify Security Groups (see `orchestrator-edge-rotator/README.md`).
   - Per-instance isolation:
     - Docker compose projects + per-instance networks
     - Sessions: `${VTUBER_SESSION_DIR}/<avatar>`

--- a/orchestrator-edge-rotator/README.md
+++ b/orchestrator-edge-rotator/README.md
@@ -8,6 +8,28 @@ This container runs on the **orchestrator GPU host** and automates the key piece
 
 It is designed to work even when the stack is “sleeping” (only `orchestrator-health` is up) by recreating containers with `docker compose up --no-start ...`.
 
+## Does this “open ports”?
+
+Not by itself.
+
+Think of inbound access as **three separate gates**:
+
+1) **A service must be listening** (a container/process is running).
+2) **The port must be published/reachable on the host** (Docker/Compose `ports:` mapping, if needed).
+3) **Network + host firewalls must allow the traffic**:
+   - **EC2 Security Groups** decide what can reach the instance at all.
+   - This rotator programs **host `iptables`** rules to restrict *who* can reach a configured set of ports (CIDR allowlist).
+
+CIDRs + `iptables` don’t “create” new ports; they only allow or deny traffic to ports that already exist.
+
+### Checklist: expose a new service port safely
+
+If you add a new container/service that must be reachable from the edge/gateway (or another remote system):
+
+1) Publish the port in compose (`ports:`) so it exists on the host.
+2) Allow that host port in the EC2 Security Group, restricted to the edge/gateway CIDR(s) (or your admin IPs for operator-only ports).
+3) Add the port to `EDGE_ALLOW_PORTS` so the rotator doesn’t drop it, then recreate `orchestrator-edge-rotator`.
+
 ## Control plane contract
 
 The rotator polls a URL (API Gateway / control plane) for desired configuration.


### PR DESCRIPTION
Closes #182.

Adds a plain-language explanation of what the edge-rotator does (iptables allowlists) vs what actually "opens ports" (service listening + Docker publish + EC2 SG), plus a short checklist for exposing a new service port.

Docs only.