### PR TITLE
Enable remote cluster control by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Remote automation (ex: Payments) can call:
 - `POST http://<host>:9090/power/projects/<compose_project>`
 
 Experimental remote spawn/delete (cluster instances):
-- Enable: set `EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1` (then recreate `orchestrator-health`, or run a cluster deploy with the prompt enabled).
+- Enabled by default for new installs (in `orchestrator.env.example`). To disable: set `EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=0` in `.env` and recreate `orchestrator-health`.
 - `POST http://<host>:9090/cluster/deploy` with JSON `{ "avatar_id": "embody-0", "slot": 0, "gpu": "0" }`
 - `POST http://<host>:9090/cluster/down` with JSON `{ "avatar_id": "embody-0" }` (or `{ "project": "vtuber-embody-0" }`)
 

--- a/orchestrator.env.example
+++ b/orchestrator.env.example
@@ -48,13 +48,13 @@ ENABLE_REST_API=0
 #
 # Experimental: allow remote cluster instance deploy/down via :9090/cluster/*
 # (Requires POWER_ALLOWED_IPS / VTUBER_ALLOWED_ADDRESSES allowlisting.)
-# EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1
+EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1
 # ORCHESTRATOR_PROJECT_DIR=/home/ubuntu/Unreal_Vtuber
 # CLUSTER_EXECUTOR_CONTAINER=vtuber-orchestrator-edge-rotator
 #
 # Experimental: allow remote ops endpoints (upgrade/rollout) via :9090/ops/*
 # (Requires POWER_ALLOWED_IPS / VTUBER_ALLOWED_ADDRESSES allowlisting.)
-# EXPERIMENTAL_REMOTE_OPS=1
+EXPERIMENTAL_REMOTE_OPS=1
 #
 # For remote rollout, the executor container needs read access to the orchestrator license token file.
 # Default token path created by `./scripts/embody_cli.sh license redeem` on Ubuntu:

--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -2680,7 +2680,7 @@ cluster_deploy() {
   remote_cluster="$(strip_inline_comment "$(read_env_value "$ENV_FILE" "EXPERIMENTAL_REMOTE_CLUSTER_CONTROL" 2>/dev/null || true)")"
   remote_cluster="$(trim_whitespace "${remote_cluster:-}")"
   if [[ "$remote_cluster" != "1" ]] && is_tty; then
-    echo "cluster: experimental remote cluster spawn/delete endpoints (:9090/cluster/*) are disabled by default." >&2
+    echo "cluster: experimental remote cluster spawn/delete endpoints (:9090/cluster/*) are disabled (set EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1 to enable)." >&2
     if prompt_yes_no "Enable remote cluster control for this deploy? (experimental)" "n"; then
       export EXPERIMENTAL_REMOTE_CLUSTER_CONTROL="1"
       echo "cluster: enabled for this run (tip: add EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1 to .env to persist)." >&2


### PR DESCRIPTION
Fixes #185

- Set `EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1` in `orchestrator.env.example` so new installs get `/cluster/*` enabled out of the box (still allowlist-protected).
- Make README/CLI messaging match the new default.