### PR TITLE
Enable cluster control by default

### DIFF
--- a/orchestrator-health/orchestrator_health/remote_health_service.py
+++ b/orchestrator-health/orchestrator_health/remote_health_service.py
@@ -219,7 +219,7 @@ def _env_truthy(key: str, default: bool = False) -> bool:
 
 
 def _require_cluster_control_enabled() -> None:
-    if not _env_truthy("EXPERIMENTAL_REMOTE_CLUSTER_CONTROL", default=False):
+    if not _env_truthy("EXPERIMENTAL_REMOTE_CLUSTER_CONTROL", default=True):
         raise HTTPException(status_code=404, detail="cluster control not enabled")
 
 


### PR DESCRIPTION
## Summary
- Change `EXPERIMENTAL_REMOTE_CLUSTER_CONTROL` default from `false` to `true`
- Removes onboarding friction for multi-avatar cluster mode
- Cluster endpoints still protected by IP allowlist

## Test plan
- [x] Verified on pon-node after manual enable
- [x] Verified on gwiz after manual enable
- [ ] Deploy to arthur and confirm `/cluster/deploy` works without env var

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes cluster control endpoints available by default.
> 
> - Changes `_require_cluster_control_enabled` to treat `EXPERIMENTAL_REMOTE_CLUSTER_CONTROL` as `true` by default in `remote_health_service.py`, enabling `/cluster/*` unless explicitly disabled
> - IP allowlist auth remains enforced via existing `_require_auth`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a65117ae18f3b83166055c65cac7d3918234222. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->