### PR TITLE
Expose log retention knobs for Portainer

### DIFF
--- a/docker-compose.unreal.instance.yml
+++ b/docker-compose.unreal.instance.yml
@@ -39,8 +39,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: "${VTUBER_SIGNALING_LOG_MAX_SIZE:-10m}"
+        max-file: "${VTUBER_SIGNALING_LOG_MAX_FILE:-3}"
 
   # Embody Game - Headless Unreal Engine with Pixel Streaming
   unreal-game:
@@ -84,8 +84,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "50m"
-        max-file: "5"
+        max-size: "${VTUBER_GAME_LOG_MAX_SIZE:-50m}"
+        max-file: "${VTUBER_GAME_LOG_MAX_FILE:-5}"
 
   vtuber-script-runner:
     image: ghcr.io/its-define/unreal_vtuber/vtuber-script-runner:${EMBODY_SERVICE_IMAGE_TAG:-latest}

--- a/docker-compose.unreal.yml
+++ b/docker-compose.unreal.yml
@@ -70,8 +70,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: "${VTUBER_SIGNALING_LOG_MAX_SIZE:-10m}"
+        max-file: "${VTUBER_SIGNALING_LOG_MAX_FILE:-3}"
 
   # Embody Game - Headless Unreal Engine with Pixel Streaming
   unreal-game:
@@ -116,8 +116,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "50m"
-        max-file: "5"
+        max-size: "${VTUBER_GAME_LOG_MAX_SIZE:-50m}"
+        max-file: "${VTUBER_GAME_LOG_MAX_FILE:-5}"
 
   vtuber-script-runner:
     image: ghcr.io/its-define/unreal_vtuber/vtuber-script-runner:${EMBODY_SERVICE_IMAGE_TAG:-latest}

--- a/docs/orchestrator-onboarding.md
+++ b/docs/orchestrator-onboarding.md
@@ -94,6 +94,25 @@ If the orchestrator doesn’t appear in Payments yet, rerun:
 docker compose -f docker-compose.unreal.yml run --rm orchestrator-registration
 ```
 
+## Portainer logs (retain more history)
+
+The default Docker log rotation for the largest containers is conservative to protect disk space:
+- Signaling: `10m x 3 files`
+- Unreal game: `50m x 5 files`
+
+If you need **more history** in Portainer, increase these in `.env`:
+```
+VTUBER_SIGNALING_LOG_MAX_SIZE=200m
+VTUBER_SIGNALING_LOG_MAX_FILE=10
+VTUBER_GAME_LOG_MAX_SIZE=1g
+VTUBER_GAME_LOG_MAX_FILE=10
+```
+
+Then recreate the services:
+```bash
+docker compose -f docker-compose.unreal.yml up -d --force-recreate unreal-signaling unreal-game
+```
+
 ## Post-onboarding verification (multi-edge)
 
 In the current multi-edge setup, user traffic hits a regional **edge** (running `ps-gateway` + matchmaker + TURN DNAT),

--- a/orchestrator.env.example
+++ b/orchestrator.env.example
@@ -23,6 +23,15 @@ RECORDER_AV_WAIT_SECONDS=3
 EMBODY_SERVICE_IMAGE_TAG=latest
 
 # ---------------------------------
+# Logging (Portainer / docker logs)
+# ---------------------------------
+# Increase these to retain more logs (useful for Portainer). Larger values consume more disk.
+VTUBER_SIGNALING_LOG_MAX_SIZE=10m
+VTUBER_SIGNALING_LOG_MAX_FILE=3
+VTUBER_GAME_LOG_MAX_SIZE=50m
+VTUBER_GAME_LOG_MAX_FILE=5
+
+# ---------------------------------
 # Networking
 # ---------------------------------
 PUBLIC_IP=auto


### PR DESCRIPTION
## Summary
- make docker log rotation settings for signaling/game configurable via .env
- document log retention knobs for Portainer in onboarding guide

## Testing
- not run (config/docs changes only)