### PR TITLE
Make remote ops opt-in with CLI toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Changes merged after `v1.3.1` (current tagged release).
 
-- (none yet)
+- Remote ops (`/ops/*`) are now opt-in (disabled by default); enable via `./scripts/embody_cli.sh remote-updates enable` or `EXPERIMENTAL_REMOTE_OPS=1`.
 
 ## v1.3.1 (2026-01-25)
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Experimental remote spawn/delete (cluster instances):
 
 Remote metadata + ops (experimental):
 - `GET http://<host>:9090/meta` (git head + container image refs/ids, plus last `verify` + pending rollout state).
-- Enabled by default (opt-out: set `EXPERIMENTAL_REMOTE_OPS=0` in `.env` and recreate `orchestrator-health`).
+- Disabled by default. Enable with `./scripts/embody_cli.sh remote-updates enable` (or set `EXPERIMENTAL_REMOTE_OPS=1` in `.env`) and recreate `orchestrator-health`.
 - Security: `/ops/*` always requires `POWER_ALLOWED_IPS` / `POWER_ALLOWED_IPS_FILE` allowlisting (otherwise returns 403).
 - `POST http://<host>:9090/ops/upgrade` with JSON `{ "apply": true }` (git ff-only update; optionally pull/recreate host-level containers).
 - `POST http://<host>:9090/ops/rollout`:

--- a/docker-compose.unreal.yml
+++ b/docker-compose.unreal.yml
@@ -198,7 +198,7 @@ services:
       # Experimental: allow remote cluster instance deploy/down via :9090/cluster/*
       - EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=${EXPERIMENTAL_REMOTE_CLUSTER_CONTROL:-1}
       # Experimental: allow remote ops endpoints via :9090/ops/*
-      - EXPERIMENTAL_REMOTE_OPS=${EXPERIMENTAL_REMOTE_OPS:-1}
+      - EXPERIMENTAL_REMOTE_OPS=${EXPERIMENTAL_REMOTE_OPS:-0}
       - ORCHESTRATOR_PROJECT_DIR=${EDGE_PROJECT_DIR:-/home/ubuntu/Unreal_Vtuber}
       - CLUSTER_EXECUTOR_CONTAINER=${CLUSTER_EXECUTOR_CONTAINER:-vtuber-orchestrator-edge-rotator}
       - CLUSTER_INSTANCE_COMPOSE_FILE=${CLUSTER_INSTANCE_COMPOSE_FILE:-docker-compose.unreal.instance.yml}

--- a/docs/embody-cli.md
+++ b/docs/embody-cli.md
@@ -71,6 +71,7 @@ q) Quit
 - `power` – sleep/wake the stack via `http://127.0.0.1:9090/power` (or a single compose project via `/power/projects/<project>`)
   - `power sleep|wake --project <compose_project>` targets one cluster instance (example: `vtuber-embody-0`)
   - `power wake --ttl <seconds>` sets an auto-sleep TTL on wake
+- `remote-updates` – enable/disable remote ops endpoints (`/ops/*`) after verifying allowlists
 - Day-to-day stack control:
   - `start`, `stop`, `restart`, `status`, `logs [service]`, `health`
 - `upgrade` – pull/recreate service containers (safe to run while sleeping; won’t wake the game)
@@ -134,7 +135,7 @@ The `orchestrator-health` service exposes remote metadata and a small remote-con
 
 ### Defaults and what changes require
 
-- Enabled by default. To disable: set `EXPERIMENTAL_REMOTE_OPS=0` in `.env` and recreate `orchestrator-health`.
+- Disabled by default. Enable via `./scripts/embody_cli.sh remote-updates enable` (or set `EXPERIMENTAL_REMOTE_OPS=1` in `.env`) and recreate `orchestrator-health`.
 - Always protected by the Power allowlist. If `POWER_ALLOWED_IPS` / `POWER_ALLOWED_IPS_FILE` is not configured, `/ops/*` returns `403`.
 - Most `orchestrator-health` env vars (including `EXPERIMENTAL_REMOTE_OPS` and `EXPERIMENTAL_REMOTE_CLUSTER_CONTROL`) are read at process startup, so changes require a recreate/restart.
 

--- a/docs/orchestrator-onboarding.md
+++ b/docs/orchestrator-onboarding.md
@@ -32,6 +32,7 @@ Notes:
 - To override storage paths: `--session-dir ...` and `--recordings-dir ...`.
 - For plain output: set `NO_COLOR=1` or pass `--no-color` (and `--no-fx` to disable transitions).
 - If you don’t have an invite code yet, abort and request one from your admin.
+- Remote updates (`/ops/*`) are disabled by default; enable during setup with `--enable-remote-updates` or later via `./scripts/embody_cli.sh remote-updates enable` (allowlist still required).
 
 Non-interactive (for automation):
 ```bash

--- a/orchestrator-health/orchestrator_health/remote_health_service.py
+++ b/orchestrator-health/orchestrator_health/remote_health_service.py
@@ -224,7 +224,7 @@ def _require_cluster_control_enabled() -> None:
 
 
 def _require_remote_ops_enabled() -> None:
-    if not _env_truthy("EXPERIMENTAL_REMOTE_OPS", default=True):
+    if not _env_truthy("EXPERIMENTAL_REMOTE_OPS", default=False):
         raise HTTPException(status_code=404, detail="remote ops not enabled")
 
 

--- a/orchestrator-health/tests/test_power_api.py
+++ b/orchestrator-health/tests/test_power_api.py
@@ -197,19 +197,19 @@ def ops_app(monkeypatch, tmp_path):
     return app, svc
 
 
-def test_ops_endpoints_require_allowlist_by_default(power_app):
+def test_ops_endpoints_disabled_by_default(power_app):
     app, _svc = power_app
     client = TestClient(app)
 
     resp = client.post("/ops/upgrade", json={"apply": False})
-    assert resp.status_code == 403
-    assert resp.json()["detail"] == "POWER_ALLOWED_IPS must be set for remote ops"
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "remote ops not enabled"
 
     resp = client.post("/ops/rollout", json={})
-    assert resp.status_code == 403
+    assert resp.status_code == 404
 
     resp = client.post("/ops/pull-image", json={"image": "ghcr.io/example/image:latest"})
-    assert resp.status_code == 403
+    assert resp.status_code == 404
 
 
 def test_ops_endpoints_can_be_disabled(monkeypatch, tmp_path):

--- a/orchestrator.env.example
+++ b/orchestrator.env.example
@@ -53,8 +53,8 @@ EXPERIMENTAL_REMOTE_CLUSTER_CONTROL=1
 # CLUSTER_EXECUTOR_CONTAINER=vtuber-orchestrator-edge-rotator
 #
 # Experimental: allow remote ops endpoints (upgrade/rollout) via :9090/ops/*
-# (Requires POWER_ALLOWED_IPS / VTUBER_ALLOWED_ADDRESSES allowlisting.)
-EXPERIMENTAL_REMOTE_OPS=1
+# (Requires POWER_ALLOWED_IPS / VTUBER_ALLOWED_ADDRESSES allowlisting; disabled by default.)
+EXPERIMENTAL_REMOTE_OPS=0
 #
 # For remote rollout, the executor container needs read access to the orchestrator license token file.
 # Default token path created by `./scripts/embody_cli.sh license redeem` on Ubuntu:

--- a/scripts/embody_cli.sh
+++ b/scripts/embody_cli.sh
@@ -65,6 +65,7 @@ Usage:
   ./scripts/embody_cli.sh register         # Register orchestrator in Payments (cached; skip when already registered)
   ./scripts/embody_cli.sh verify           # Full health/consistency checks (optionally auto-fix)
   ./scripts/embody_cli.sh power            # Sleep/wake via orchestrator-health /power
+  ./scripts/embody_cli.sh remote-updates   # Toggle remote ops (/ops/*) allowlist-gated
   ./scripts/embody_cli.sh cluster <cmd>    # Multi-instance cluster mode (plan/list/up/down/status/logs)
 
 Day-to-day commands:
@@ -1107,7 +1108,7 @@ PY
           echo "$body" >&2
         fi
         echo "Hint: ensure the stack is sleeping (power sleep) and POWER_ALLOWED_IPS allowlisting includes 127.0.0.1 (remote /ops is strict)." >&2
-        echo "If you opted out of remote ops (EXPERIMENTAL_REMOTE_OPS=0), set it back to 1 and recreate orchestrator-health." >&2
+        echo "If remote updates are disabled (EXPERIMENTAL_REMOTE_OPS=0), enable with ./scripts/embody_cli.sh remote-updates enable and recreate orchestrator-health." >&2
         return 1
       fi
       echo "$body"
@@ -1143,10 +1144,20 @@ cmd_config() {
   allowlist="$(strip_inline_comment "$(read_env_value "$ENV_FILE" "VTUBER_ALLOWED_ADDRESSES" 2>/dev/null || true)")"
   turn_external="$(strip_inline_comment "$(read_env_value "$ENV_FILE" "TURN_EXTERNAL_IP" 2>/dev/null || true)")"
   gpu_devices="$(strip_inline_comment "$(read_env_value "$ENV_FILE" "NVIDIA_VISIBLE_DEVICES" 2>/dev/null || true)")"
+  local remote_ops remote_ops_state
+  remote_ops="$(strip_inline_comment "$(read_env_value "$ENV_FILE" "EXPERIMENTAL_REMOTE_OPS" 2>/dev/null || true)")"
+  remote_ops="$(trim_whitespace "${remote_ops:-}")"
+  if [[ "$remote_ops" == "1" ]]; then
+    remote_ops_state="enabled"
+  else
+    remote_ops_state="disabled"
+    remote_ops="${remote_ops:-0}"
+  fi
 
   echo "Orchestrator ID:        ${orch_id:-<unset>}"
   echo "Payout wallet:          ${orch_addr:-<unset>}"
   echo "Payments API:           ${payments_url:-<unset>}"
+  echo "Remote updates:         ${remote_ops_state} (EXPERIMENTAL_REMOTE_OPS=${remote_ops})"
   echo "Allowed caller IPs:     ${allowlist:-<unset>}"
   echo "TURN external IP:       ${turn_external:-<unset>}"
   echo "GPU devices:            ${gpu_devices:-all}"
@@ -1159,6 +1170,115 @@ cmd_config() {
     echo "TURN env:               present (${TURN_ENV_FILE})"
   else
     echo "TURN env:               missing (${TURN_ENV_FILE})"
+  fi
+}
+
+cmd_remote_updates() {
+  local sub="${1:-status}"
+  shift || true
+  local apply="auto"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help|help)
+        cat <<'EOF'
+Usage:
+  ./scripts/embody_cli.sh remote-updates [status]
+  ./scripts/embody_cli.sh remote-updates enable [--apply]
+  ./scripts/embody_cli.sh remote-updates disable [--apply]
+
+Notes:
+  - Remote updates expose /ops/* endpoints on orchestrator-health.
+  - Access is still gated by POWER_ALLOWED_IPS / POWER_ALLOWED_IPS_FILE.
+  - Use --apply to recreate orchestrator-health immediately.
+EOF
+        return 0
+        ;;
+      --apply|--recreate)
+        apply="1"
+        shift 1
+        ;;
+      --no-recreate)
+        apply="0"
+        shift 1
+        ;;
+      *)
+        echo "Unknown arg: $1" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing .env (run: ./scripts/embody_cli.sh setup)" >&2
+    return 1
+  fi
+
+  local current state
+  current="$(strip_inline_comment "$(read_env_value "$ENV_FILE" "EXPERIMENTAL_REMOTE_OPS" 2>/dev/null || true)")"
+  current="$(trim_whitespace "${current:-}")"
+  if [[ "$current" == "1" ]]; then
+    state="enabled"
+  else
+    state="disabled"
+    current="${current:-0}"
+  fi
+
+  if [[ -z "$sub" || "$sub" == "status" ]]; then
+    echo "Remote updates: ${state} (EXPERIMENTAL_REMOTE_OPS=${current})"
+    if [[ "$state" == "enabled" ]]; then
+      echo "Allowlist: POWER_ALLOWED_IPS / POWER_ALLOWED_IPS_FILE must include trusted IPs."
+    fi
+    return 0
+  fi
+
+  local next=""
+  case "$sub" in
+    enable|on)
+      next="1"
+      ;;
+    disable|off)
+      next="0"
+      ;;
+    *)
+      echo "Unknown subcommand: $sub (use: status|enable|disable)" >&2
+      return 1
+      ;;
+  esac
+
+  if ! upsert_env_kv "$ENV_FILE" "EXPERIMENTAL_REMOTE_OPS" "$next"; then
+    echo "Failed to update ${ENV_FILE}" >&2
+    return 1
+  fi
+
+  if [[ "$next" == "1" ]]; then
+    echo "Remote updates enabled (EXPERIMENTAL_REMOTE_OPS=1)."
+  else
+    echo "Remote updates disabled (EXPERIMENTAL_REMOTE_OPS=0)."
+  fi
+
+  local apply_now="$apply"
+  if [[ "$apply_now" == "auto" ]]; then
+    if is_tty && prompt_yes_no "Recreate orchestrator-health now to apply?" "y"; then
+      apply_now="1"
+    else
+      apply_now="0"
+    fi
+  fi
+
+  if [[ "$apply_now" == "1" ]]; then
+    if ! docker compose --project-directory "$REPO_ROOT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" \
+      up -d --force-recreate orchestrator-health >/dev/null 2>&1; then
+      echo "Failed to recreate orchestrator-health" >&2
+      return 1
+    fi
+    echo "orchestrator-health recreated."
+  else
+    echo "Run to apply: docker compose --project-directory \"$REPO_ROOT\" --env-file \"$ENV_FILE\" -f \"$COMPOSE_FILE\" up -d --force-recreate orchestrator-health"
+  fi
+
+  if [[ "$next" == "1" ]]; then
+    echo "Reminder: /ops/* is allowlist-protected (POWER_ALLOWED_IPS / POWER_ALLOWED_IPS_FILE)."
   fi
 }
 
@@ -4544,6 +4664,7 @@ menu() {
     ui_menu_item "v" "Verify (end-to-end)"
     ui_menu_item "m" "Payments status"
     ui_menu_item "p" "Power (sleep/wake)"
+    ui_menu_item "o" "Remote updates (ops)"
     ui_menu_item "s" "Setup / reconfigure"
     ui_menu_item "q" "Quit"
     printf '> '
@@ -4579,6 +4700,14 @@ menu() {
         act="$(trim_whitespace "${act:-}")"
         [[ -n "$act" ]] || act="status"
         cmd_power "$act" || true
+        ;;
+      o|O)
+        echo -n "Remote updates (status|enable|disable): "
+        local act
+        read -r act || true
+        act="$(trim_whitespace "${act:-}")"
+        [[ -n "$act" ]] || act="status"
+        cmd_remote_updates "$act" || true
         ;;
       s|S) "$ONBOARD_SCRIPT" ;;
       q|Q) exit 0 ;;
@@ -4722,6 +4851,10 @@ main() {
     payments)
       shift || true
       cmd_payments "$@"
+      ;;
+    remote-updates|remote-ops)
+      shift || true
+      cmd_remote_updates "$@"
       ;;
     allowlists|allowlist)
       shift || true

--- a/scripts/embody_onboard.sh
+++ b/scripts/embody_onboard.sh
@@ -58,6 +58,8 @@ Behavior flags:
   --interactive               Force the CLI wizard (even if flags are provided)
   --non-interactive           Never prompt; error if required values are missing
   --advanced                  Prompt for optional settings (Payments URL, extra edge IPs, host paths)
+  --enable-remote-updates     Enable remote updates (/ops/*) during setup
+  --disable-remote-updates    Disable remote updates (/ops/*) during setup
   --no-color                  Disable ANSI colors
   --no-fx                     Disable transition effects
   --install-deps              Attempt apt-get install of curl/jq/zstd/age/python3 (Ubuntu/Debian only)
@@ -325,6 +327,21 @@ read_env_value() {
   ' "$file"
 }
 
+read_existing_remote_ops() {
+  local raw
+  raw="$(read_env_value "$ENV_FILE" "EXPERIMENTAL_REMOTE_OPS" 2>/dev/null || true)"
+  if [[ -z "$raw" ]]; then
+    raw="$(read_env_value "$ENV_TEMPLATE" "EXPERIMENTAL_REMOTE_OPS" 2>/dev/null || true)"
+  fi
+  raw="$(trim_whitespace "${raw:-}")"
+  raw="$(strip_inline_comment "$raw")"
+  if [[ "$raw" == "1" ]]; then
+    echo "1"
+  else
+    echo "0"
+  fi
+}
+
 seed_power_allowlist_file_best_effort() {
   local path="$1" wanted="$2"
   [[ -n "$path" ]] || return 0
@@ -433,6 +450,8 @@ NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES:-}"
 
 CONTROL_IPS=()
 
+REMOTE_OPS_ENABLED=""
+
 INSTALL_DEPS="0"
 INSTALL_DOCKER="0"
 INSTALL_NVIDIA_DRIVER="0"
@@ -469,6 +488,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --advanced)
       ADVANCED="1"
+      shift 1
+      ;;
+    --enable-remote-updates|--enable-remote-ops)
+      REMOTE_OPS_ENABLED="1"
+      shift 1
+      ;;
+    --disable-remote-updates|--disable-remote-ops)
+      REMOTE_OPS_ENABLED="0"
       shift 1
       ;;
     --no-color)
@@ -1749,6 +1776,24 @@ maybe_run_wizard() {
     fi
   fi
 
+  section "Remote Updates (optional)"
+  local existing_remote_ops default_remote_ops
+  existing_remote_ops="$(read_existing_remote_ops)"
+  if [[ -z "$REMOTE_OPS_ENABLED" ]]; then
+    default_remote_ops="n"
+    if [[ "$existing_remote_ops" == "1" ]]; then
+      default_remote_ops="y"
+    fi
+    if prompt_yes_no "Enable remote updates (remote /ops/*)?" "$default_remote_ops"; then
+      REMOTE_OPS_ENABLED="1"
+    else
+      REMOTE_OPS_ENABLED="0"
+    fi
+  fi
+  if [[ "$REMOTE_OPS_ENABLED" == "1" ]]; then
+    note "Remote updates are allowlist-protected (POWER_ALLOWED_IPS / POWER_ALLOWED_IPS_FILE)."
+  fi
+
   if [[ "$PUBLIC_IP" == "auto" ]]; then
     fx_dots "Detecting public IP"
     local detected
@@ -1823,6 +1868,11 @@ maybe_run_wizard() {
   fi
   echo "Public IP:           $PUBLIC_IP" >&2
   echo "GPU devices:         ${NVIDIA_VISIBLE_DEVICES:-all}" >&2
+  if [[ "$REMOTE_OPS_ENABLED" == "1" ]]; then
+    echo "Remote updates:      enabled" >&2
+  else
+    echo "Remote updates:      disabled" >&2
+  fi
   if [[ -n "$EDGE_CONFIG_URL" ]]; then
     echo "Edge config plane:   $EDGE_CONFIG_URL" >&2
   else
@@ -1913,6 +1963,10 @@ maybe_run_wizard() {
 
 maybe_run_wizard
 
+if [[ -z "$REMOTE_OPS_ENABLED" ]]; then
+  REMOTE_OPS_ENABLED="$(read_existing_remote_ops)"
+fi
+
 if [[ -z "$ORCH_ID" ]]; then
   die "--orchestrator-id is required (or run without --non-interactive to use the wizard)"
 fi
@@ -2002,6 +2056,7 @@ upsert_env_kv "$ENV_FILE" "PUBLIC_IP" "$PUBLIC_IP"
 upsert_env_kv "$ENV_FILE" "ORCHESTRATOR_HOST_PUBLIC_IP" "$PUBLIC_IP"
 upsert_env_kv "$ENV_FILE" "ORCHESTRATOR_HEALTH_URL" "http://$PUBLIC_IP:9090/health"
 upsert_env_kv "$ENV_FILE" "EDGE_PROJECT_DIR" "$REPO_ROOT"
+upsert_env_kv "$ENV_FILE" "EXPERIMENTAL_REMOTE_OPS" "$REMOTE_OPS_ENABLED"
 
 EDGE_CONFIG_URL="$(trim_whitespace "$EDGE_CONFIG_URL")"
 EDGE_CONFIG_URL="$(strip_inline_comment "$EDGE_CONFIG_URL")"


### PR DESCRIPTION
## Summary
- default remote ops (/ops/*) to off and gate via CLI toggle or .env
- add onboarding prompt + CLI command to enable/disable and show status
- update docs/changelog and adjust tests for new default

## Testing
- python3 -m pytest orchestrator-health/tests/test_power_api.py (fails: pytest not installed)