### PR TITLE
PixelStreaming2: set keyframe interval + LowLatency defaults

### DIFF
--- a/pixel-streaming/config/Engine.ini
+++ b/pixel-streaming/config/Engine.ini
@@ -18,3 +18,37 @@ CodecPreferences=H264
 ; Some builds/branches use b-prefixed bool names; keep both for safety.
 bWebRTCNegotiateCodecs=True
 
+; -----------------------------------------------------------------------------
+; Encoder stability defaults (long-running streams)
+; -----------------------------------------------------------------------------
+; UltraLowLatency can suppress periodic IDR frames at the NVENC level, which is
+; great for pure WebRTC latency but can cause quality to degrade over time in
+; long-running broadcasts. LowLatency still keeps things snappy while allowing
+; periodic keyframes.
+Encoder.LatencyMode=LowLatency
+
+; Force periodic keyframes so decoders (and downstream RTMP pipelines) can
+; recover from drift/packet loss. Twitch ingest guidance is typically 2s.
+; 60 frames ~= 2s @ 30fps.
+Encoder.KeyFrameInterval=60
+; Some branches/versions use a lowercased "f" in logs/config; keep both.
+Encoder.KeyframeInterval=60
+
+; Baseline is the safest profile for broad decode compatibility.
+Encoder.H264Profile=Baseline
+
+; -----------------------------------------------------------------------------
+; Legacy / alternate namespaces (UE versions vary; keep "shotgun" overrides)
+; -----------------------------------------------------------------------------
+
+[/Script/PixelStreaming.PixelStreamingSettings]
+; Pixel Streaming v1 (legacy). Kept for older builds.
+Codec=H264
+
+[PixelStreaming2]
+; PixelStreaming2 CVar namespace fallback.
+Encoder.Codec=H264
+Encoder.LatencyMode=LowLatency
+Encoder.KeyFrameInterval=60
+Encoder.KeyframeInterval=60
+Encoder.H264Profile=Baseline


### PR DESCRIPTION
Sets long-run stability defaults in the mounted pixel-streaming/config/Engine.ini:

- Encoder.LatencyMode=LowLatency (avoids UltraLowLatency suppressing IDR frames)
- Encoder.KeyFrameInterval=60 (periodic keyframes; ~2s @ 30fps)
- Keeps H.264 Baseline
- Adds legacy/alternate namespaces (PixelStreaming v1 + [PixelStreaming2]) for UE version variance

Intended to prevent gradual H.264 quality degradation/pixelation during long-running streams and improve decoder recovery.